### PR TITLE
feat: add auth scaffold and search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,16 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/razkazvach
 REDIS_URL=redis://localhost:6379
 
 # Search (future bites)
+# Auth.js (Email provider)
+AUTH_SECRET=changeme-long-random
+EMAIL_FROM="Razkazvach <no-reply@razkazvach.local>"
+EMAIL_SERVER=smtp://user:pass@localhost:1025
+
+# Meili
 MEILI_HOST=http://localhost:7700
 MEILI_API_KEY=masterKey
+MEILI_INDEX_STORIES=stories
+
+# Storage (local adapter)
+ASSETS_DIR=./uploads
+ASSETS_PUBLIC_BASE=/api/assets

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test-results
 tsconfig.tsbuildinfo
 v8-compile-cache-*
 .DS_Store
+uploads

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Razkazvach — Foundation (Bite #1)
+# Razkazvach — Foundation (Bite #2)
 
 ## Prereqs
 
@@ -8,7 +8,9 @@
 
 1. `cp .env.example .env.local` and adjust as needed.
 2. Install deps: `pnpm install`.
-3. (Optional) Start dev services: `docker compose -f docker-compose.services.yml up -d`.
+3. Start dev services: `docker compose -f docker-compose.services.yml up -d` (brings up Postgres, Meili, Valkey, Mailpit).
+4. Run DB migrations: `pnpm dlx prisma migrate dev --name init_core`.
+5. Seed data: `pnpm db:seed`.
 
 ## Dev
 
@@ -17,6 +19,7 @@
 - `pnpm typecheck` — TS types.
 - `pnpm test` — unit tests.
 - `pnpm e2e` — end-to-end tests (builds and runs the app).
+- `pnpm db:seed` — seed database with demo stories and admin user.
 
 ## CI
 
@@ -25,3 +28,13 @@ GitHub Actions runs lint → typecheck → unit → build → e2e for pushes and
 ## Docker (production image)
 
 - `docker build -t razkazvach:latest .`
+
+## Auth & Admin
+
+- Visit `/auth/signin` and enter the seeded admin email (default `admin@example.com`).
+- Open Mailpit at [http://localhost:8025](http://localhost:8025) to access magic links.
+- `/admin` is protected by role (`ADMIN` or `EDITOR`).
+
+## Storage
+
+- Local uploads are stored under `./uploads` and served from `/api/assets/*`.

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -1,0 +1,41 @@
+"use server";
+import { prisma } from "@/lib/prisma";
+import { StoryUpsertSchema } from "@/lib/validators";
+import { z } from "zod";
+import { revalidatePath } from "next/cache";
+import { upsertStoryIndex } from "@/lib/search";
+
+export async function upsertStory(formData: FormData) {
+  const parsed = StoryUpsertSchema.safeParse(Object.fromEntries(formData));
+  if (!parsed.success) throw new Error("Invalid story payload");
+  const { id, bodyHtml, ...fields } = parsed.data as z.infer<
+    typeof StoryUpsertSchema
+  >;
+
+  const story = await prisma.story.upsert({
+    where: { id: id ?? "" },
+    update: {
+      ...fields,
+      body: bodyHtml
+        ? { upsert: { create: { html: bodyHtml }, update: { html: bodyHtml } } }
+        : undefined,
+    },
+    create: {
+      ...fields,
+      body: bodyHtml ? { create: { html: bodyHtml } } : undefined,
+    },
+  });
+  revalidatePath("/admin");
+  return { id: story.id };
+}
+
+export async function publishStory(id: string) {
+  const s = await prisma.story.update({
+    where: { id },
+    data: { status: "PUBLISHED", publishedAt: new Date() },
+    include: { body: true },
+  });
+  await upsertStoryIndex(s);
+  revalidatePath(`/prikazki/${s.slug}`);
+  return { ok: true };
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,39 @@
+import { prisma } from "@/lib/prisma";
+import Link from "next/link";
+
+export default async function AdminPage() {
+  const stories = await prisma.story.findMany({
+    orderBy: { updatedAt: "desc" },
+  });
+  return (
+    <main className="mx-auto max-w-4xl p-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Admin</h1>
+        <Link
+          className="rounded bg-black px-3 py-2 text-white"
+          href="/admin/stories/new"
+        >
+          New Story
+        </Link>
+      </div>
+      <ul className="mt-4 space-y-2">
+        {stories.map((s) => (
+          <li
+            key={s.id}
+            className="rounded border p-3 flex items-center justify-between"
+          >
+            <div>
+              <div className="font-medium">{s.title}</div>
+              <div className="text-sm text-gray-500">
+                {s.status} · /prikazki/{s.slug}
+              </div>
+            </div>
+            <Link className="underline" href={`/admin/stories/${s.id}`}>
+              Edit
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/admin/stories/[id]/page.tsx
+++ b/app/admin/stories/[id]/page.tsx
@@ -1,0 +1,87 @@
+import { prisma } from "@/lib/prisma";
+import { upsertStory, publishStory } from "@/app/admin/actions";
+
+export default async function EditStory({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const s = await prisma.story.findUnique({
+    where: { id: params.id },
+    include: { body: true },
+  });
+  if (!s) return <div className="p-6">Not found</div>;
+  return (
+    <main className="mx-auto max-w-2xl p-6">
+      <h1 className="text-2xl font-bold">Edit Story</h1>
+      <form action={upsertStory} className="mt-4 space-y-3">
+        <input type="hidden" name="id" value={s.id} />
+        <input
+          name="title"
+          defaultValue={s.title}
+          className="w-full rounded border p-2"
+        />
+        <input
+          name="slug"
+          defaultValue={s.slug}
+          className="w-full rounded border p-2"
+        />
+        <textarea
+          name="description"
+          defaultValue={s.description}
+          className="w-full rounded border p-2"
+          rows={3}
+        />
+        <input
+          name="tags"
+          defaultValue={s.tags.join(", ")}
+          className="w-full rounded border p-2"
+        />
+        <div className="flex gap-2">
+          <input
+            name="ageMin"
+            type="number"
+            defaultValue={s.ageMin}
+            className="w-24 rounded border p-2"
+          />
+          <input
+            name="ageMax"
+            type="number"
+            defaultValue={s.ageMax}
+            className="w-24 rounded border p-2"
+          />
+        </div>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            name="isInteractive"
+            defaultChecked={s.isInteractive}
+          />{" "}
+          Interactive
+        </label>
+        <textarea
+          name="bodyHtml"
+          defaultValue={s.body?.html ?? ""}
+          className="w-full rounded border p-2"
+          rows={10}
+        />
+        <div className="flex items-center gap-3">
+          <button className="rounded bg-black px-4 py-2 text-white">
+            Save
+          </button>
+          {s.status !== "PUBLISHED" && (
+            <button
+              formAction={async () => {
+                "use server";
+                await publishStory(s.id);
+              }}
+              className="rounded bg-green-600 px-4 py-2 text-white"
+            >
+              Publish
+            </button>
+          )}
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/app/admin/stories/new/page.tsx
+++ b/app/admin/stories/new/page.tsx
@@ -1,0 +1,65 @@
+import { upsertStory } from "@/app/admin/actions";
+import { toSlug } from "@/lib/slug";
+
+export default function NewStory() {
+  return (
+    <main className="mx-auto max-w-2xl p-6">
+      <h1 className="text-2xl font-bold">New Story</h1>
+      <form action={upsertStory} className="mt-4 space-y-3">
+        <input
+          name="title"
+          placeholder="Title"
+          className="w-full rounded border p-2"
+          required
+        />
+        <input
+          name="slug"
+          placeholder="slug"
+          className="w-full rounded border p-2"
+          onChange={(e) =>
+            (e.currentTarget.value = toSlug(e.currentTarget.value))
+          }
+        />
+        <textarea
+          name="description"
+          placeholder="Short description"
+          className="w-full rounded border p-2"
+          rows={3}
+        />
+        <input
+          name="tags"
+          placeholder="tag1, tag2"
+          className="w-full rounded border p-2"
+        />
+        <div className="flex gap-2">
+          <input
+            name="ageMin"
+            type="number"
+            defaultValue={3}
+            min={3}
+            max={12}
+            className="w-24 rounded border p-2"
+          />
+          <input
+            name="ageMax"
+            type="number"
+            defaultValue={8}
+            min={3}
+            max={12}
+            className="w-24 rounded border p-2"
+          />
+        </div>
+        <label className="flex items-center gap-2">
+          <input type="checkbox" name="isInteractive" /> Interactive
+        </label>
+        <textarea
+          name="bodyHtml"
+          placeholder="Story HTML (flow text)"
+          className="w-full rounded border p-2"
+          rows={10}
+        />
+        <button className="rounded bg-black px-4 py-2 text-white">Save</button>
+      </form>
+    </main>
+  );
+}

--- a/app/api/assets/[...key]/route.ts
+++ b/app/api/assets/[...key]/route.ts
@@ -1,0 +1,13 @@
+import fs from "fs";
+import path from "path";
+import { NextResponse } from "next/server";
+
+export async function GET(_: Request, ctx: { params: { key: string[] } }) {
+  const key = ctx.params.key.join("/");
+  const baseDir = process.env.ASSETS_DIR || "./uploads";
+  const filePath = path.join(baseDir, key);
+  if (!fs.existsSync(filePath))
+    return new NextResponse("Not found", { status: 404 });
+  const stream = fs.createReadStream(filePath);
+  return new NextResponse(stream as unknown as BodyInit);
+}

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,1 @@
+export { handlers as GET, handlers as POST } from "@/auth";

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { searchStories } from "@/lib/search";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get("q");
+  if (!q || q.length < 2) return NextResponse.json({ hits: [] });
+  const result = await searchStories(q);
+  return NextResponse.json(result);
+}

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+import { signIn } from "next-auth/react";
+import { useState } from "react";
+
+export default function SignInPage() {
+  const [email, setEmail] = useState("");
+  return (
+    <main className="mx-auto max-w-md p-6">
+      <h1 className="text-2xl font-bold">Sign in</h1>
+      <p className="mt-2 text-sm text-gray-600">
+        Enter your email to receive a magic link.
+      </p>
+      <form
+        onSubmit={async (e) => {
+          e.preventDefault();
+          await signIn("email", { email });
+        }}
+        className="mt-4 space-y-3"
+      >
+        <input
+          className="w-full rounded border p-2"
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@example.com"
+        />
+        <button className="rounded bg-black px-4 py-2 text-white">
+          Send link
+        </button>
+      </form>
+      <p className="mt-4 text-xs text-gray-500">
+        Dev: open Mailpit at{" "}
+        <a className="underline" href="http://localhost:8025" target="_blank">
+          localhost:8025
+        </a>
+      </p>
+    </main>
+  );
+}

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+import { useState } from "react";
+
+export default function SearchPage() {
+  const [q, setQ] = useState("");
+  const [hits, setHits] = useState<
+    { id: string; title: string; description: string }[]
+  >([]);
+  return (
+    <main className="mx-auto max-w-2xl p-6">
+      <h1 className="text-2xl font-bold">Search</h1>
+      <form
+        onSubmit={async (e) => {
+          e.preventDefault();
+          const r = await fetch(`/api/search?q=${encodeURIComponent(q)}`);
+          const j = await r.json();
+          setHits(j.hits || []);
+        }}
+        className="mt-4"
+      >
+        <input
+          className="w-full rounded border p-2"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Търси приказка..."
+        />
+      </form>
+      <ul className="mt-4 space-y-2">
+        {hits.map((h) => (
+          <li key={h.id} className="rounded border p-3">
+            <div className="font-medium">{h.title}</div>
+            <div className="text-sm text-gray-600">{h.description}</div>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/auth.ts
+++ b/auth.ts
@@ -1,0 +1,27 @@
+import NextAuth from "next-auth";
+import { PrismaAdapter } from "@auth/prisma-adapter";
+import EmailProvider from "next-auth/providers/email";
+import type { NextAuthConfig } from "next-auth";
+import { prisma } from "@/lib/prisma";
+
+export const authConfig: NextAuthConfig = {
+  adapter: PrismaAdapter(prisma),
+  providers: [
+    EmailProvider({
+      server: process.env.EMAIL_SERVER!,
+      from: process.env.EMAIL_FROM!,
+      maxAge: 10 * 60,
+    }),
+  ],
+  session: { strategy: "database" },
+  callbacks: {
+    async session({ session, user }) {
+      if (session.user) (session.user as { role?: string }).role = user.role;
+      return session;
+    },
+  },
+  pages: { signIn: "/auth/signin" },
+  secret: process.env.AUTH_SECRET,
+};
+
+export const { handlers, auth, signIn, signOut } = NextAuth(authConfig);

--- a/docker-compose.services.yml
+++ b/docker-compose.services.yml
@@ -25,6 +25,13 @@ services:
     volumes:
       - meili:/meili_data
 
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: rz-mailpit
+    ports:
+      - "8025:8025"
+      - "1025:1025"
+
 volumes:
   pgdata:
   meili:

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,12 @@
+import { PrismaClient } from "@prisma/client";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined;
+}
+
+export const prisma = globalThis.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") {
+  globalThis.prisma = prisma;
+}

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,0 +1,52 @@
+import { MeiliSearch } from "meilisearch";
+import type { Story } from "@prisma/client";
+
+const client = new MeiliSearch({
+  host: process.env.MEILI_HOST!,
+  apiKey: process.env.MEILI_API_KEY,
+});
+const indexName = process.env.MEILI_INDEX_STORIES || "stories";
+
+export async function ensureStoryIndex() {
+  const index = await client
+    .getIndex(indexName)
+    .catch(() => client.createIndex(indexName, { primaryKey: "id" }));
+  await index.updateSettings({
+    searchableAttributes: ["title", "description", "tags"],
+    filterableAttributes: ["ageMin", "ageMax", "status"],
+    sortableAttributes: ["publishedAt"],
+  });
+  return index;
+}
+
+export async function upsertStoryIndex(
+  s: Story & { body?: { html: string | null } | null },
+) {
+  try {
+    const index = await ensureStoryIndex();
+    return index.addDocuments([
+      {
+        id: s.id,
+        slug: s.slug,
+        title: s.title,
+        description: s.description,
+        tags: s.tags,
+        ageMin: s.ageMin,
+        ageMax: s.ageMax,
+        status: s.status,
+        publishedAt: s.publishedAt,
+      },
+    ]);
+  } catch {
+    return;
+  }
+}
+
+export async function searchStories(q: string) {
+  try {
+    const index = await ensureStoryIndex();
+    return index.search(q, { limit: 10 });
+  } catch {
+    return { hits: [] } as { hits: unknown[] };
+  }
+}

--- a/lib/slug.ts
+++ b/lib/slug.ts
@@ -1,0 +1,44 @@
+export function toSlug(s: string) {
+  const map: Record<string, string> = {
+    а: "a",
+    б: "b",
+    в: "v",
+    г: "g",
+    д: "d",
+    е: "e",
+    ж: "zh",
+    з: "z",
+    и: "i",
+    й: "y",
+    к: "k",
+    л: "l",
+    м: "m",
+    н: "n",
+    о: "o",
+    п: "p",
+    р: "r",
+    с: "s",
+    т: "t",
+    у: "u",
+    ф: "f",
+    х: "h",
+    ц: "c",
+    ч: "ch",
+    ш: "sh",
+    щ: "sht",
+    ъ: "a",
+    ь: "",
+    ю: "yu",
+    я: "ya",
+  };
+  return s
+    .toLowerCase()
+    .split("")
+    .map((ch) => map[ch] ?? ch)
+    .join("")
+    .normalize("NFKD")
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,0 +1,26 @@
+import fs from "fs/promises";
+import path from "path";
+
+export interface StorageAdapter {
+  putObject(key: string, data: Buffer | Uint8Array): Promise<void>;
+  getUrl(key: string): string;
+  deleteObject(key: string): Promise<void>;
+}
+
+const baseDir = process.env.ASSETS_DIR || "./uploads";
+const publicBase = process.env.ASSETS_PUBLIC_BASE || "/api/assets";
+
+export const LocalStorage: StorageAdapter = {
+  async putObject(key, data) {
+    const p = path.join(baseDir, key);
+    await fs.mkdir(path.dirname(p), { recursive: true });
+    await fs.writeFile(p, data);
+  },
+  getUrl(key) {
+    return `${publicBase}/${encodeURIComponent(key)}`;
+  },
+  async deleteObject(key) {
+    const p = path.join(baseDir, key);
+    await fs.rm(p, { force: true });
+  },
+};

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const StoryUpsertSchema = z.object({
+  id: z.string().optional(),
+  title: z.string().min(3).max(120),
+  slug: z
+    .string()
+    .min(3)
+    .max(140)
+    .regex(/^[a-z0-9-]+$/),
+  description: z.string().min(10).max(500),
+  tags: z
+    .string()
+    .transform((s) =>
+      s
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean),
+    )
+    .optional(),
+  ageMin: z.coerce.number().min(3).max(12),
+  ageMax: z.coerce.number().min(3).max(12),
+  isInteractive: z.coerce.boolean().optional().default(false),
+  bodyHtml: z.string().optional(),
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+
+export default auth((req) => {
+  const { nextUrl, auth: session } = req;
+  if (nextUrl.pathname.startsWith("/admin")) {
+    const role = (session?.user as { role?: string })?.role;
+    if (!role || (role !== "ADMIN" && role !== "EDITOR")) {
+      return NextResponse.redirect(new URL("/auth/signin", nextUrl));
+    }
+  }
+});
+
+export const config = { matcher: ["/admin/:path*"] };

--- a/package.json
+++ b/package.json
@@ -17,11 +17,17 @@
     "test:watch": "vitest tests/unit",
     "e2e": "playwright test",
     "e2e:headed": "playwright test --headed",
+    "db:seed": "tsx prisma/seed.ts",
     "postinstall": "prisma generate",
     "prepare": "husky install"
   },
   "dependencies": {
+    "@auth/prisma-adapter": "^2.10.0",
+    "@prisma/client": "5.22.0",
+    "meilisearch": "^0.52.0",
     "next": "14.2.5",
+    "next-auth": "^4.24.11",
+    "nodemailer": "^7.0.5",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "zod": "^3.23.8"
@@ -47,6 +53,7 @@
     "prettier-plugin-tailwindcss": "^0.6.5",
     "prisma": "^5.16.1",
     "tailwindcss": "^3.4.7",
+    "tsx": "^4.20.5",
     "typescript": "5.5.4",
     "vitest": "^2.0.5"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,24 @@ importers:
 
   .:
     dependencies:
+      '@auth/prisma-adapter':
+        specifier: ^2.10.0
+        version: 2.10.0(@prisma/client@5.22.0(prisma@5.22.0))(nodemailer@7.0.5)
+      '@prisma/client':
+        specifier: 5.22.0
+        version: 5.22.0(prisma@5.22.0)
+      meilisearch:
+        specifier: ^0.52.0
+        version: 0.52.0
       next:
         specifier: 14.2.5
         version: 14.2.5(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next-auth:
+        specifier: ^4.24.11
+        version: 4.24.11(next@14.2.5(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@7.0.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      nodemailer:
+        specifier: ^7.0.5
+        version: 7.0.5
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -81,6 +96,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.7
         version: 3.4.17
+      tsx:
+        specifier: ^4.20.5
+        version: 4.20.5
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -94,12 +112,35 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@auth/core@0.40.0':
+    resolution: {integrity: sha512-n53uJE0RH5SqZ7N1xZoMKekbHfQgjd0sAEyUbE+IYJnmuQkbvuZnXItCU7d+i7Fj8VGOgqvNO7Mw4YfBTlZeQw==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^6.8.0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
+  '@auth/prisma-adapter@2.10.0':
+    resolution: {integrity: sha512-EliOQoTjGK87jWWqnJvlQjbR4PjQZQqtwRwPAe108WwT9ubuuJJIrL68aNnQr4hFESz6P7SEX2bZy+y2yL37Gw==}
+    peerDependencies:
+      '@prisma/client': '>=2.26.0 || >=3 || >=4 || >=5 || >=6'
+
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.27.1':
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.28.3':
+    resolution: {integrity: sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==}
     engines: {node: '>=6.9.0'}
 
   '@commitlint/cli@19.8.1':
@@ -186,9 +227,21 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.25.9':
+    resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.9':
+    resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -198,9 +251,21 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.25.9':
+    resolution: {integrity: sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.9':
+    resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -210,9 +275,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.25.9':
+    resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.9':
+    resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -222,9 +299,21 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.25.9':
+    resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.9':
+    resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -234,9 +323,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.25.9':
+    resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.9':
+    resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -246,9 +347,21 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.9':
+    resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.9':
+    resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -258,9 +371,21 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.9':
+    resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.9':
+    resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -270,9 +395,21 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.9':
+    resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.9':
+    resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -282,11 +419,35 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.9':
+    resolution: {integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.9':
+    resolution: {integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
@@ -294,9 +455,27 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.25.9':
+    resolution: {integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.9':
+    resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -306,15 +485,33 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.25.9':
+    resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.9':
+    resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.9':
+    resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -445,6 +642,9 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@panva/hkdf@1.2.1':
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -453,6 +653,15 @@ packages:
     resolution: {integrity: sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@prisma/client@5.22.0':
+    resolution: {integrity: sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==}
+    engines: {node: '>=16.13'}
+    peerDependencies:
+      prisma: '*'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
 
   '@prisma/debug@5.22.0':
     resolution: {integrity: sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==}
@@ -1075,6 +1284,10 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   cosmiconfig-typescript-loader@6.1.0:
     resolution: {integrity: sha512-tJ1w35ZRUiM5FeTzT7DtYWAFFv37ZLqSRkGi2oeCK1gPhvaWjkAtfXvLmvE1pRfxxp9aQo6ba/Pvg1dKj05D4g==}
     engines: {node: '>=v18'}
@@ -1245,6 +1458,11 @@ packages:
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.25.9:
+    resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escalade@3.2.0:
@@ -1787,6 +2005,12 @@ packages:
     resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
     hasBin: true
 
+  jose@4.15.9:
+    resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
+
+  jose@6.0.13:
+    resolution: {integrity: sha512-Yms4GpbmdANamS51kKK6w4hRlKx8KTxbWyAAKT/MhUMtqbIqh5mb2HjhTNUbk7TFL8/MBB5zWSDohL7ed4k/UA==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1900,12 +2124,19 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
   magic-string@0.30.18:
     resolution: {integrity: sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  meilisearch@0.52.0:
+    resolution: {integrity: sha512-RqPsB4a78sXf/ATB7PIVvKCG7yf0y1M+uCj8Z9Wku44WmCy3iz0C1PHjVV5xphQolo09CdhdyFoRxHQSJkOdpg==}
 
   meow@12.1.1:
     resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
@@ -1967,6 +2198,20 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  next-auth@4.24.11:
+    resolution: {integrity: sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==}
+    peerDependencies:
+      '@auth/core': 0.34.2
+      next: ^12.2.5 || ^13 || ^14 || ^15
+      nodemailer: ^6.6.5
+      react: ^17.0.2 || ^18 || ^19
+      react-dom: ^17.0.2 || ^18 || ^19
+    peerDependenciesMeta:
+      '@auth/core':
+        optional: true
+      nodemailer:
+        optional: true
+
   next@14.2.5:
     resolution: {integrity: sha512-0f8aRfBVL+mpzfBjYfQuLWh2WyAwtJXCRfkPF4UJ5qd2YwrHczsrSzXU4tRMV0OAxR8ZJZWPFn6uhSC56UTsLA==}
     engines: {node: '>=18.17.0'}
@@ -1988,6 +2233,10 @@ packages:
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
+  nodemailer@7.0.5:
+    resolution: {integrity: sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==}
+    engines: {node: '>=6.0.0'}
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -2000,9 +2249,19 @@ packages:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  oauth4webapi@3.7.0:
+    resolution: {integrity: sha512-Q52wTPUWPsVLVVmTViXPQFMW2h2xv2jnDGxypjpelCFKaOjLsm7AxYuOk1oQgFm95VNDbuggasu9htXrz6XwKw==}
+
+  oauth@0.9.15:
+    resolution: {integrity: sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-hash@2.2.0:
+    resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
+    engines: {node: '>= 6'}
 
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
@@ -2036,6 +2295,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  oidc-token-hash@5.1.1:
+    resolution: {integrity: sha512-D7EmwxJV6DsEB6vOFLrBM2OzsVgQzgPWyHlV2OOAVj772n+WTXpudC9e9u5BVKQnYwaD30Ivhi9b+4UeBcGu9g==}
+    engines: {node: ^10.13.0 || >=12.0.0}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -2046,6 +2309,9 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  openid-client@5.7.1:
+    resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -2203,6 +2469,22 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  preact-render-to-string@5.2.6:
+    resolution: {integrity: sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==}
+    peerDependencies:
+      preact: '>=10'
+
+  preact-render-to-string@6.5.11:
+    resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
+    peerDependencies:
+      preact: '>=10'
+
+  preact@10.24.3:
+    resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
+
+  preact@10.27.1:
+    resolution: {integrity: sha512-V79raXEWch/rbqoNc7nT9E4ep7lu+mI3+sBmfRD4i1M73R3WLYcCtdI0ibxGVf4eQL8ZIz2nFacqEC+rmnOORQ==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -2272,6 +2554,9 @@ packages:
     resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
     engines: {node: '>=14'}
     hasBin: true
+
+  pretty-format@3.8.0:
+    resolution: {integrity: sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==}
 
   prisma@5.22.0:
     resolution: {integrity: sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==}
@@ -2628,6 +2913,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.20.5:
+    resolution: {integrity: sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -2682,6 +2972,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -2793,6 +3087,9 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
   yaml@2.8.1:
     resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
     engines: {node: '>= 14.6'}
@@ -2821,6 +3118,25 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@auth/core@0.40.0(nodemailer@7.0.5)':
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      jose: 6.0.13
+      oauth4webapi: 3.7.0
+      preact: 10.24.3
+      preact-render-to-string: 6.5.11(preact@10.24.3)
+    optionalDependencies:
+      nodemailer: 7.0.5
+
+  '@auth/prisma-adapter@2.10.0(@prisma/client@5.22.0(prisma@5.22.0))(nodemailer@7.0.5)':
+    dependencies:
+      '@auth/core': 0.40.0(nodemailer@7.0.5)
+      '@prisma/client': 5.22.0(prisma@5.22.0)
+    transitivePeerDependencies:
+      - '@simplewebauthn/browser'
+      - '@simplewebauthn/server'
+      - nodemailer
+
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
@@ -2828,6 +3144,8 @@ snapshots:
       picocolors: 1.1.1
 
   '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/runtime@7.28.3': {}
 
   '@commitlint/cli@19.8.1(@types/node@20.19.11)(typescript@5.5.4)':
     dependencies:
@@ -2958,70 +3276,148 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.9':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.9':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.25.9':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.25.9':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.9':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.9':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.9':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.9':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.9':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.9':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.9':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.9':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.9':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.9':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.9':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.9':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    optional: true
+
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.9':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    optional: true
+
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.9':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.25.9':
+    optional: true
+
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.9':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.9':
     optional: true
 
   '@eslint-community/eslint-utils@4.7.0(eslint@8.57.1)':
@@ -3136,12 +3532,18 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@panva/hkdf@1.2.1': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
   '@playwright/test@1.55.0':
     dependencies:
       playwright: 1.55.0
+
+  '@prisma/client@5.22.0(prisma@5.22.0)':
+    optionalDependencies:
+      prisma: 5.22.0
 
   '@prisma/debug@5.22.0': {}
 
@@ -3777,6 +4179,8 @@ snapshots:
       meow: 12.1.1
       split2: 4.2.0
 
+  cookie@0.7.2: {}
+
   cosmiconfig-typescript-loader@6.1.0(@types/node@20.19.11)(cosmiconfig@9.0.0(typescript@5.5.4))(typescript@5.5.4):
     dependencies:
       '@types/node': 20.19.11
@@ -4021,6 +4425,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.21.5
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.25.9:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.9
+      '@esbuild/android-arm': 0.25.9
+      '@esbuild/android-arm64': 0.25.9
+      '@esbuild/android-x64': 0.25.9
+      '@esbuild/darwin-arm64': 0.25.9
+      '@esbuild/darwin-x64': 0.25.9
+      '@esbuild/freebsd-arm64': 0.25.9
+      '@esbuild/freebsd-x64': 0.25.9
+      '@esbuild/linux-arm': 0.25.9
+      '@esbuild/linux-arm64': 0.25.9
+      '@esbuild/linux-ia32': 0.25.9
+      '@esbuild/linux-loong64': 0.25.9
+      '@esbuild/linux-mips64el': 0.25.9
+      '@esbuild/linux-ppc64': 0.25.9
+      '@esbuild/linux-riscv64': 0.25.9
+      '@esbuild/linux-s390x': 0.25.9
+      '@esbuild/linux-x64': 0.25.9
+      '@esbuild/netbsd-arm64': 0.25.9
+      '@esbuild/netbsd-x64': 0.25.9
+      '@esbuild/openbsd-arm64': 0.25.9
+      '@esbuild/openbsd-x64': 0.25.9
+      '@esbuild/openharmony-arm64': 0.25.9
+      '@esbuild/sunos-x64': 0.25.9
+      '@esbuild/win32-arm64': 0.25.9
+      '@esbuild/win32-ia32': 0.25.9
+      '@esbuild/win32-x64': 0.25.9
 
   escalade@3.2.0: {}
 
@@ -4651,6 +5084,10 @@ snapshots:
 
   jiti@2.5.1: {}
 
+  jose@4.15.9: {}
+
+  jose@6.0.13: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.0:
@@ -4765,11 +5202,17 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
+
   magic-string@0.30.18:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
+
+  meilisearch@0.52.0: {}
 
   meow@12.1.1: {}
 
@@ -4816,6 +5259,23 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  next-auth@4.24.11(next@14.2.5(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@7.0.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@panva/hkdf': 1.2.1
+      cookie: 0.7.2
+      jose: 4.15.9
+      next: 14.2.5(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      oauth: 0.9.15
+      openid-client: 5.7.1
+      preact: 10.27.1
+      preact-render-to-string: 5.2.6(preact@10.27.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      uuid: 8.3.2
+    optionalDependencies:
+      nodemailer: 7.0.5
+
   next@14.2.5(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.5
@@ -4844,6 +5304,8 @@ snapshots:
 
   node-releases@2.0.19: {}
 
+  nodemailer@7.0.5: {}
+
   normalize-path@3.0.0: {}
 
   normalize-range@0.1.2: {}
@@ -4852,7 +5314,13 @@ snapshots:
     dependencies:
       path-key: 4.0.0
 
+  oauth4webapi@3.7.0: {}
+
+  oauth@0.9.15: {}
+
   object-assign@4.1.1: {}
+
+  object-hash@2.2.0: {}
 
   object-hash@3.0.0: {}
 
@@ -4896,6 +5364,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  oidc-token-hash@5.1.1: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -4907,6 +5377,13 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  openid-client@5.7.1:
+    dependencies:
+      jose: 4.15.9
+      lru-cache: 6.0.0
+      object-hash: 2.2.0
+      oidc-token-hash: 5.1.1
 
   optionator@0.9.4:
     dependencies:
@@ -5040,6 +5517,19 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  preact-render-to-string@5.2.6(preact@10.27.1):
+    dependencies:
+      preact: 10.27.1
+      pretty-format: 3.8.0
+
+  preact-render-to-string@6.5.11(preact@10.24.3):
+    dependencies:
+      preact: 10.24.3
+
+  preact@10.24.3: {}
+
+  preact@10.27.1: {}
+
   prelude-ls@1.2.1: {}
 
   prettier-plugin-tailwindcss@0.6.14(prettier@3.6.2):
@@ -5047,6 +5537,8 @@ snapshots:
       prettier: 3.6.2
 
   prettier@3.6.2: {}
+
+  pretty-format@3.8.0: {}
 
   prisma@5.22.0:
     dependencies:
@@ -5471,6 +5963,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.20.5:
+    dependencies:
+      esbuild: 0.25.9
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -5558,6 +6057,8 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  uuid@8.3.2: {}
 
   vite-node@2.1.9(@types/node@20.19.11):
     dependencies:
@@ -5694,6 +6195,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   y18n@5.0.8: {}
+
+  yallist@4.0.0: {}
 
   yaml@2.8.1: {}
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,9 +7,200 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-// Minimal model so prisma generate works cleanly
+// ---------------------- Auth.js (Prisma Adapter) ----------------------
 model User {
-  id        String   @id @default(cuid())
-  email     String   @unique
-  createdAt DateTime @default(now())
+  id        String    @id @default(cuid())
+  email     String    @unique
+  name      String?
+  image     String?
+  role      Role      @default(USER)
+  createdAt DateTime  @default(now())
+
+  sessions  Session[]
+  accounts  Account[]
+
+  // App relations
+  subscriptions   Subscription[]
+  readingProgress ReadingProgress[]
+  events          Event[]
+  experiments     UserExperimentAssignment[]
 }
+
+enum Role {
+  ADMIN
+  EDITOR
+  USER
+}
+
+model Account {
+  id                String  @id @default(cuid())
+  userId            String
+  type              String
+  provider          String
+  providerAccountId String
+  refresh_token     String?
+  access_token      String?
+  expires_at        Int?
+  token_type        String?
+  scope             String?
+  id_token          String?
+  session_state     String?
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+}
+
+model Session {
+  id           String   @id @default(cuid())
+  sessionToken String   @unique
+  userId       String
+  expires      DateTime
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model VerificationToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
+}
+
+// --------------------------- Core domain ------------------------------
+model Subscription {
+  id               String   @id @default(cuid())
+  userId           String
+  provider         String   @default("stripe")
+  status           String   @default("inactive")
+  plan             String   @default("monthly") // monthly|semiannual|annual
+  currentPeriodEnd DateTime?
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+}
+
+model Story {
+  id           String    @id @default(cuid())
+  slug         String    @unique
+  title        String
+  description  String
+  ageMin       Int       @default(3)
+  ageMax       Int       @default(8)
+  tags         String[]  @default([])
+  coverUrl     String?
+  status       StoryStatus @default(DRAFT)
+  isInteractive Boolean   @default(false)
+  publishedAt  DateTime?
+  createdAt    DateTime   @default(now())
+  updatedAt    DateTime   @updatedAt
+
+  body            StoryBody?
+  audio           AudioAsset?
+  nodes           InteractiveNode[]
+  readingProgress ReadingProgress[]
+  freeRotation    FreeRotation?
+}
+
+enum StoryStatus {
+  DRAFT
+  REVIEW
+  PUBLISHED
+}
+
+model StoryBody {
+  storyId        String   @id
+  lang           String   @default("bg")
+  html           String
+  readingTimeSec Int      @default(0)
+  story          Story    @relation(fields: [storyId], references: [id], onDelete: Cascade)
+}
+
+model AudioAsset {
+  id         String   @id @default(cuid())
+  storyId    String   @unique
+  voice      String
+  url        String
+  durationSec Int
+  quality     String   @default("std")
+  generatedAt DateTime @default(now())
+  story      Story    @relation(fields: [storyId], references: [id], onDelete: Cascade)
+}
+
+model InteractiveNode {
+  id       String  @id @default(cuid())
+  storyId  String
+  bodyHtml String
+  story    Story   @relation(fields: [storyId], references: [id], onDelete: Cascade)
+  outgoing InteractiveChoice[] @relation("FromNode")
+  incoming InteractiveChoice[] @relation("ToNode")
+
+  @@index([storyId])
+}
+
+model InteractiveChoice {
+  id         String @id @default(cuid())
+  fromNodeId String
+  label      String
+  toNodeId   String
+
+  fromNode InteractiveNode @relation("FromNode", fields: [fromNodeId], references: [id], onDelete: Cascade)
+  toNode   InteractiveNode @relation("ToNode",   fields: [toNodeId],   references: [id], onDelete: Cascade)
+
+  @@index([fromNodeId])
+  @@index([toNodeId])
+}
+
+model ReadingProgress {
+  userId   String
+  storyId  String
+  lastPos  String   // e.g., caret offset or nodeId for interactive
+  updatedAt DateTime @default(now())
+
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  story Story @relation(fields: [storyId], references: [id], onDelete: Cascade)
+
+  @@id([userId, storyId])
+}
+
+model Event {
+  id     String   @id @default(cuid())
+  userId String?
+  name   String
+  props  Json
+  ts     DateTime @default(now())
+
+  user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  @@index([userId])
+  @@index([name, ts])
+}
+
+model ExperimentConfig {
+  key      String  @id
+  variants Json
+  updatedAt DateTime @updatedAt
+}
+
+model UserExperimentAssignment {
+  userId  String
+  key     String
+  variant String
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([userId, key])
+}
+
+model FreeRotation {
+  id       String  @id @default(cuid())
+  storyId  String  @unique
+  monthKey String  // e.g., 2025-08
+  priority Int     @default(0)
+  story    Story   @relation(fields: [storyId], references: [id], onDelete: Cascade)
+}
+

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,73 @@
+import { PrismaClient } from "@prisma/client";
+const prisma = new PrismaClient();
+
+async function main() {
+  // Admin/editor bootstrap email (for local login)
+  const adminEmail = process.env.SEED_ADMIN_EMAIL || "admin@example.com";
+  await prisma.user.upsert({
+    where: { email: adminEmail },
+    update: { role: "ADMIN" },
+    create: { email: adminEmail, role: "ADMIN" },
+  });
+
+  // Linear story
+  const s1 = await prisma.story.upsert({
+    where: { slug: "prikazka-za-lisicata" },
+    update: {},
+    create: {
+      slug: "prikazka-za-lisicata",
+      title: "Приказка за Лисицата",
+      description: "Топла, кратка приказка за деца 3–8",
+      tags: ["животни", "приятелство"],
+      ageMin: 3,
+      ageMax: 8,
+      status: "DRAFT",
+      body: {
+        create: {
+          lang: "bg",
+          html: "<p>Имало едно време една умна лисица...</p>",
+          readingTimeSec: 120,
+        },
+      },
+    },
+  });
+
+  // Interactive demo
+  const s2 = await prisma.story.upsert({
+    where: { slug: "interaktivna-prikazka-demo" },
+    update: {},
+    create: {
+      slug: "interaktivna-prikazka-demo",
+      title: "Интерактивна Приказка (Демо)",
+      description: "Една изборна история с 3 възела",
+      tags: ["интерактивна", "демо"],
+      isInteractive: true,
+      status: "DRAFT",
+    },
+  });
+
+  const n1 = await prisma.interactiveNode.create({
+    data: { storyId: s2.id, bodyHtml: "<p>Начало: лява или дясна пътека?</p>" },
+  });
+  const n2 = await prisma.interactiveNode.create({
+    data: { storyId: s2.id, bodyHtml: "<p>Ляво: намираш приятел.</p>" },
+  });
+  const n3 = await prisma.interactiveNode.create({
+    data: { storyId: s2.id, bodyHtml: "<p>Дясно: научаваш урок.</p>" },
+  });
+  await prisma.interactiveChoice.createMany({
+    data: [
+      { fromNodeId: n1.id, toNodeId: n2.id, label: "Ляво" },
+      { fromNodeId: n1.id, toNodeId: n3.id, label: "Дясно" },
+    ],
+  });
+
+  console.log("Seed complete:", { adminEmail, s1: s1.slug, s2: s2.slug });
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => prisma.$disconnect());

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from "@playwright/test";
+
+test("admin requires auth", async ({ page }) => {
+  const res = await page.goto("/admin");
+  expect(res?.status()).toBe(200);
+  await expect(page).toHaveURL(/\/auth\/signin/);
+});

--- a/tests/e2e/basic.spec.ts
+++ b/tests/e2e/basic.spec.ts
@@ -11,3 +11,8 @@ test("health endpoint", async ({ request }) => {
   const json = await res.json();
   expect(json.ok).toBe(true);
 });
+
+test("search endpoint", async ({ request }) => {
+  const res = await request.get("/api/search?q=demo");
+  expect(res.status()).toBe(200);
+});

--- a/tests/unit/slug.spec.ts
+++ b/tests/unit/slug.spec.ts
@@ -1,0 +1,8 @@
+import { toSlug } from "../../lib/slug";
+import { describe, it, expect } from "vitest";
+
+describe("toSlug", () => {
+  it("normalizes text", () => {
+    expect(toSlug(" Приказка за Лисицата! ")).toBe("prikazka-za-lisicata");
+  });
+});

--- a/tests/unit/validators.spec.ts
+++ b/tests/unit/validators.spec.ts
@@ -1,0 +1,19 @@
+import { StoryUpsertSchema } from "../../lib/validators";
+import { describe, it, expect } from "vitest";
+
+describe("StoryUpsertSchema", () => {
+  it("parses basic story", () => {
+    const data = {
+      title: "Test Story",
+      slug: "test-story",
+      description: "short description here",
+      tags: "tag1, tag2",
+      ageMin: 3,
+      ageMax: 8,
+      isInteractive: false,
+    };
+    const parsed = StoryUpsertSchema.parse(data);
+    expect(parsed.slug).toBe("test-story");
+    expect(parsed.tags).toEqual(["tag1", "tag2"]);
+  });
+});


### PR DESCRIPTION
## Summary
- build core Prisma schema with auth, stories, and experiments
- implement email-based auth, admin scaffold, and local storage adapter
- integrate Meili search with API endpoint and search page

## Testing
- `pnpm dlx prisma migrate dev --name init_core` *(fails: Can't reach database server)*
- `pnpm dlx prisma generate`
- `pnpm db:seed` *(fails: Failed to deserialize constructor options)*
- `pnpm test`
- `pnpm e2e` *(fails: Could not find a production build)*

------
https://chatgpt.com/codex/tasks/task_e_68aadab59a18832cbe44def050aeeaee