### PR TITLE
feat: add auth, search, admin scaffold

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,12 +2,26 @@
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 NODE_ENV=development
 
-# Database (not used by runtime in Bite #1)
+# Database
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/razkazvach
 
-# Cache / Queue (future bites)
+# Cache / Queue
 REDIS_URL=redis://localhost:6379
 
-# Search (future bites)
+# Auth.js (Email provider)
+AUTH_SECRET=changeme-long-random
+EMAIL_FROM="Razkazvach <no-reply@razkazvach.local>"
+# For dev, run Mailpit via docker (below) and use this SMTP server
+EMAIL_SERVER=smtp://user:pass@localhost:1025
+
+# Meili
 MEILI_HOST=http://localhost:7700
 MEILI_API_KEY=masterKey
+MEILI_INDEX_STORIES=stories
+
+# Storage (local adapter)
+ASSETS_DIR=./uploads
+ASSETS_PUBLIC_BASE=/api/assets
+
+# Seed
+SEED_ADMIN_EMAIL=admin@example.com

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Razkazvach — Foundation (Bite #1)
+# Razkazvach — Foundation (Bite #2)
 
 ## Prereqs
 
@@ -6,9 +6,10 @@
 
 ## Setup
 
-1. `cp .env.example .env.local` and adjust as needed.
+1. `cp .env.example .env.local` and adjust as needed. See `.env.example` for auth, Meili and storage vars.
 2. Install deps: `pnpm install`.
-3. (Optional) Start dev services: `docker compose -f docker-compose.services.yml up -d`.
+3. Start dev services (Postgres, Meili, Mailpit, etc.): `docker compose -f docker-compose.services.yml up -d`.
+4. Run migrations and seed: `pnpm dlx prisma migrate dev --name init_core` then `pnpm db:seed`.
 
 ## Dev
 
@@ -17,6 +18,15 @@
 - `pnpm typecheck` — TS types.
 - `pnpm test` — unit tests.
 - `pnpm e2e` — end-to-end tests (builds and runs the app).
+- `pnpm db:seed` — seed database with admin user and demo stories.
+
+Mailpit captures magic link emails at [http://localhost:8025](http://localhost:8025).
+
+Admin routes (`/admin`) require `ADMIN` or `EDITOR` role and redirect unauthenticated users to `/auth/signin`.
+
+Uploaded files are stored under `./uploads` and served via `/api/assets/*`.
+
+Type safety: NextAuth uses JWT strategy with module augmentation (`types/next-auth.d.ts`).
 
 ## CI
 

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -1,0 +1,45 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+import { StoryUpsertSchema } from "@/lib/validators";
+import { z } from "zod";
+import { revalidatePath } from "next/cache";
+import { upsertStoryIndex } from "@/lib/search";
+
+export async function upsertStoryAction(formData: FormData): Promise<void> {
+  const parsed = StoryUpsertSchema.safeParse(Object.fromEntries(formData));
+  if (!parsed.success) throw new Error("Invalid story payload");
+
+  const isInteractive = formData.get("isInteractive") ? true : false;
+  const { id, bodyHtml, ...rest } = parsed.data as z.infer<
+    typeof StoryUpsertSchema
+  >;
+
+  await prisma.story.upsert({
+    where: { id: id ?? "" },
+    update: {
+      ...rest,
+      isInteractive,
+      body: bodyHtml
+        ? { upsert: { create: { html: bodyHtml }, update: { html: bodyHtml } } }
+        : undefined,
+    },
+    create: {
+      ...rest,
+      isInteractive,
+      body: bodyHtml ? { create: { html: bodyHtml } } : undefined,
+    },
+  });
+
+  revalidatePath("/admin");
+}
+
+export async function publishStoryAction(id: string): Promise<void> {
+  const s = await prisma.story.update({
+    where: { id },
+    data: { status: "PUBLISHED", publishedAt: new Date() },
+    include: { body: true },
+  });
+  await upsertStoryIndex(s);
+  revalidatePath(`/prikazki/${s.slug}`);
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,39 @@
+import { prisma } from "@/lib/prisma";
+import Link from "next/link";
+
+export default async function AdminPage() {
+  const stories = await prisma.story.findMany({
+    orderBy: { updatedAt: "desc" },
+  });
+  return (
+    <main className="mx-auto max-w-4xl p-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Admin</h1>
+        <Link
+          className="rounded bg-black px-3 py-2 text-white"
+          href="/admin/stories/new"
+        >
+          New Story
+        </Link>
+      </div>
+      <ul className="mt-4 space-y-2">
+        {stories.map((s) => (
+          <li
+            key={s.id}
+            className="rounded border p-3 flex items-center justify-between"
+          >
+            <div>
+              <div className="font-medium">{s.title}</div>
+              <div className="text-sm text-gray-500">
+                {s.status} · /prikazki/{s.slug}
+              </div>
+            </div>
+            <Link className="underline" href={`/admin/stories/${s.id}`}>
+              Edit
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/admin/stories/[id]/page.tsx
+++ b/app/admin/stories/[id]/page.tsx
@@ -1,0 +1,87 @@
+import { prisma } from "@/lib/prisma";
+import { upsertStoryAction, publishStoryAction } from "@/app/admin/actions";
+
+export default async function EditStory({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const s = await prisma.story.findUnique({
+    where: { id: params.id },
+    include: { body: true },
+  });
+  if (!s) return <div className="p-6">Not found</div>;
+
+  const publish = publishStoryAction.bind(null, s.id);
+
+  return (
+    <main className="mx-auto max-w-2xl p-6">
+      <h1 className="text-2xl font-bold">Edit Story</h1>
+      <form action={upsertStoryAction} className="mt-4 space-y-3">
+        <input type="hidden" name="id" value={s.id} />
+        <input
+          name="title"
+          defaultValue={s.title}
+          className="w-full rounded border p-2"
+        />
+        <input
+          name="slug"
+          defaultValue={s.slug}
+          className="w-full rounded border p-2"
+        />
+        <textarea
+          name="description"
+          defaultValue={s.description}
+          className="w-full rounded border p-2"
+          rows={3}
+        />
+        <input
+          name="tags"
+          defaultValue={s.tags.join(", ")}
+          className="w-full rounded border p-2"
+        />
+        <div className="flex gap-2">
+          <input
+            name="ageMin"
+            type="number"
+            defaultValue={s.ageMin}
+            className="w-24 rounded border p-2"
+          />
+          <input
+            name="ageMax"
+            type="number"
+            defaultValue={s.ageMax}
+            className="w-24 rounded border p-2"
+          />
+        </div>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            name="isInteractive"
+            defaultChecked={s.isInteractive}
+          />{" "}
+          Interactive
+        </label>
+        <textarea
+          name="bodyHtml"
+          defaultValue={s.body?.html ?? ""}
+          className="w-full rounded border p-2"
+          rows={10}
+        />
+        <div className="flex items-center gap-3">
+          <button className="rounded bg-black px-4 py-2 text-white">
+            Save
+          </button>
+          {s.status !== "PUBLISHED" && (
+            <button
+              formAction={publish}
+              className="rounded bg-green-600 px-4 py-2 text-white"
+            >
+              Publish
+            </button>
+          )}
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/app/admin/stories/new/page.tsx
+++ b/app/admin/stories/new/page.tsx
@@ -1,0 +1,65 @@
+import { upsertStoryAction } from "@/app/admin/actions";
+import { toSlug } from "@/lib/slug";
+
+export default function NewStory() {
+  return (
+    <main className="mx-auto max-w-2xl p-6">
+      <h1 className="text-2xl font-bold">New Story</h1>
+      <form action={upsertStoryAction} className="mt-4 space-y-3">
+        <input
+          name="title"
+          placeholder="Title"
+          className="w-full rounded border p-2"
+          required
+        />
+        <input
+          name="slug"
+          placeholder="slug"
+          className="w-full rounded border p-2"
+          onChange={(e) =>
+            (e.currentTarget.value = toSlug(e.currentTarget.value))
+          }
+        />
+        <textarea
+          name="description"
+          placeholder="Short description"
+          className="w-full rounded border p-2"
+          rows={3}
+        />
+        <input
+          name="tags"
+          placeholder="tag1, tag2"
+          className="w-full rounded border p-2"
+        />
+        <div className="flex gap-2">
+          <input
+            name="ageMin"
+            type="number"
+            defaultValue={3}
+            min={3}
+            max={12}
+            className="w-24 rounded border p-2"
+          />
+          <input
+            name="ageMax"
+            type="number"
+            defaultValue={8}
+            min={3}
+            max={12}
+            className="w-24 rounded border p-2"
+          />
+        </div>
+        <label className="flex items-center gap-2">
+          <input type="checkbox" name="isInteractive" /> Interactive
+        </label>
+        <textarea
+          name="bodyHtml"
+          placeholder="Story HTML (flow text)"
+          className="w-full rounded border p-2"
+          rows={10}
+        />
+        <button className="rounded bg-black px-4 py-2 text-white">Save</button>
+      </form>
+    </main>
+  );
+}

--- a/app/api/assets/[...key]/route.ts
+++ b/app/api/assets/[...key]/route.ts
@@ -1,0 +1,18 @@
+import fs from "fs";
+import path from "path";
+import { NextResponse } from "next/server";
+
+const baseDir = process.env.ASSETS_DIR || "./uploads";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { key: string[] } },
+) {
+  const filePath = path.join(baseDir, ...params.key);
+  try {
+    const stream = fs.createReadStream(filePath);
+    return new NextResponse(stream as unknown as BodyInit);
+  } catch {
+    return new NextResponse("Not found", { status: 404 });
+  }
+}

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,1 @@
+export { handlers as GET, handlers as POST } from "@/auth";

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { searchStories } from "@/lib/search";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get("q");
+  if (!q || q.length < 2) return NextResponse.json({ hits: [] });
+  const result = await searchStories(q);
+  return NextResponse.json(result);
+}

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { signIn } from "next-auth/react";
+import { useState } from "react";
+
+export default function SignInPage() {
+  const [email, setEmail] = useState("");
+  return (
+    <main className="mx-auto max-w-md p-6">
+      <h1 className="text-2xl font-bold">Sign in</h1>
+      <p className="mt-2 text-sm text-gray-600">
+        Enter your email to receive a magic link.
+      </p>
+      <form
+        onSubmit={async (e) => {
+          e.preventDefault();
+          await signIn("email", { email });
+        }}
+        className="mt-4 space-y-3"
+      >
+        <input
+          className="w-full rounded border p-2"
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@example.com"
+        />
+        <button className="rounded bg-black px-4 py-2 text-white">
+          Send link
+        </button>
+      </form>
+      <p className="mt-4 text-xs text-gray-500">
+        Dev: open Mailpit at{" "}
+        <a className="underline" href="http://localhost:8025" target="_blank">
+          localhost:8025
+        </a>
+      </p>
+    </main>
+  );
+}

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+
+export default function SearchPage() {
+  const [q, setQ] = useState("");
+  type Hit = { id: string; title: string; description: string };
+  const [hits, setHits] = useState<Hit[]>([]);
+  return (
+    <main className="mx-auto max-w-2xl p-6">
+      <h1 className="text-2xl font-bold">Search</h1>
+      <form
+        onSubmit={async (e) => {
+          e.preventDefault();
+          const r = await fetch(`/api/search?q=${encodeURIComponent(q)}`);
+          const j = await r.json();
+          setHits(j.hits || []);
+        }}
+        className="mt-4"
+      >
+        <input
+          className="w-full rounded border p-2"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Търси приказка..."
+        />
+      </form>
+      <ul className="mt-4 space-y-2">
+        {hits.map((h) => (
+          <li key={h.id} className="rounded border p-3">
+            <div className="font-medium">{h.title}</div>
+            <div className="text-sm text-gray-600">{h.description}</div>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/auth.ts
+++ b/auth.ts
@@ -1,0 +1,34 @@
+import NextAuth, { type NextAuthConfig } from "next-auth";
+import { PrismaAdapter } from "@auth/prisma-adapter";
+import EmailProvider from "next-auth/providers/nodemailer";
+import { prisma } from "@/lib/prisma";
+import type { JWT } from "next-auth/jwt";
+import type { User } from "@prisma/client";
+
+export const authConfig: NextAuthConfig = {
+  adapter: PrismaAdapter(prisma),
+  session: { strategy: "jwt" },
+  providers: [
+    EmailProvider({
+      server: process.env.EMAIL_SERVER!,
+      from: process.env.EMAIL_FROM!,
+      maxAge: 10 * 60,
+    }),
+  ],
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) (token as JWT).role = (user as User).role ?? "USER";
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user)
+        (session.user as { role?: string }).role =
+          (token as JWT).role ?? "USER";
+      return session;
+    },
+  },
+  pages: { signIn: "/auth/signin" },
+  secret: process.env.AUTH_SECRET,
+};
+
+export const { handlers, auth, signIn, signOut } = NextAuth(authConfig);

--- a/docker-compose.services.yml
+++ b/docker-compose.services.yml
@@ -25,6 +25,13 @@ services:
     volumes:
       - meili:/meili_data
 
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: rz-mailpit
+    ports:
+      - "8025:8025"   # Web UI http://localhost:8025
+      - "1025:1025"   # SMTP server
+
 volumes:
   pgdata:
   meili:

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,11 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined;
+};
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,0 +1,43 @@
+import { MeiliSearch } from "meilisearch";
+import type { Story } from "@prisma/client";
+
+const client = new MeiliSearch({
+  host: process.env.MEILI_HOST!,
+  apiKey: process.env.MEILI_API_KEY,
+});
+const indexName = process.env.MEILI_INDEX_STORIES || "stories";
+
+export async function ensureStoryIndex() {
+  await client.createIndex(indexName, { primaryKey: "id" }).catch(() => {});
+  const index = client.index(indexName);
+  await index.updateSettings({
+    searchableAttributes: ["title", "description", "tags"],
+    filterableAttributes: ["ageMin", "ageMax", "status"],
+    sortableAttributes: ["publishedAt"],
+  });
+  return index;
+}
+
+export async function upsertStoryIndex(
+  s: Story & { body?: { html: string | null } | null },
+) {
+  const index = await ensureStoryIndex();
+  await index.addDocuments([
+    {
+      id: s.id,
+      slug: s.slug,
+      title: s.title,
+      description: s.description,
+      tags: s.tags,
+      ageMin: s.ageMin,
+      ageMax: s.ageMax,
+      status: s.status,
+      publishedAt: s.publishedAt,
+    },
+  ]);
+}
+
+export async function searchStories(q: string) {
+  const index = await ensureStoryIndex();
+  return index.search(q, { limit: 10 });
+}

--- a/lib/slug.ts
+++ b/lib/slug.ts
@@ -1,0 +1,46 @@
+const cyrillicMap: Record<string, string> = {
+  а: "a",
+  б: "b",
+  в: "v",
+  г: "g",
+  д: "d",
+  е: "e",
+  ж: "zh",
+  з: "z",
+  и: "i",
+  й: "y",
+  к: "k",
+  л: "l",
+  м: "m",
+  н: "n",
+  о: "o",
+  п: "p",
+  р: "r",
+  с: "s",
+  т: "t",
+  у: "u",
+  ф: "f",
+  х: "h",
+  ц: "c",
+  ч: "ch",
+  ш: "sh",
+  щ: "sht",
+  ъ: "a",
+  ь: "",
+  ю: "yu",
+  я: "ya",
+};
+
+export function toSlug(s: string) {
+  const translit = s
+    .toLowerCase()
+    .split("")
+    .map((ch) => cyrillicMap[ch] ?? ch)
+    .join("");
+  return translit
+    .normalize("NFKD")
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,0 +1,26 @@
+import fs from "fs/promises";
+import path from "path";
+
+export interface StorageAdapter {
+  putObject(key: string, data: Buffer | Uint8Array): Promise<void>;
+  getUrl(key: string): string;
+  deleteObject(key: string): Promise<void>;
+}
+
+const baseDir = process.env.ASSETS_DIR || "./uploads";
+const publicBase = process.env.ASSETS_PUBLIC_BASE || "/api/assets";
+
+export const LocalStorage: StorageAdapter = {
+  async putObject(key, data) {
+    const p = path.join(baseDir, key);
+    await fs.mkdir(path.dirname(p), { recursive: true });
+    await fs.writeFile(p, data);
+  },
+  getUrl(key) {
+    return `${publicBase}/${encodeURIComponent(key)}`;
+  },
+  async deleteObject(key) {
+    const p = path.join(baseDir, key);
+    await fs.rm(p, { force: true });
+  },
+};

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+export const StoryUpsertSchema = z.object({
+  id: z.string().optional(),
+  title: z.string().min(3).max(120),
+  slug: z
+    .string()
+    .min(3)
+    .max(140)
+    .regex(/^[a-z0-9-]+$/),
+  description: z.string().min(10).max(500),
+  tags: z
+    .string()
+    .transform((s) =>
+      s
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean),
+    )
+    .optional(),
+  ageMin: z.coerce.number().min(3).max(12),
+  ageMax: z.coerce.number().min(3).max(12),
+  bodyHtml: z.string().optional(),
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,18 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+
+export async function middleware(req: NextRequest) {
+  const url = req.nextUrl;
+  if (url.pathname.startsWith("/admin")) {
+    const session = await auth();
+    const role = (session?.user as { role?: string } | undefined)?.role;
+    if (!role || (role !== "ADMIN" && role !== "EDITOR")) {
+      const signInUrl = new URL("/auth/signin", url);
+      return NextResponse.redirect(signInUrl);
+    }
+  }
+  return NextResponse.next();
+}
+
+export const config = { matcher: ["/admin/:path*"] };

--- a/package.json
+++ b/package.json
@@ -17,11 +17,17 @@
     "test:watch": "vitest tests/unit",
     "e2e": "playwright test",
     "e2e:headed": "playwright test --headed",
+    "db:seed": "tsx prisma/seed.ts",
     "postinstall": "prisma generate",
     "prepare": "husky install"
   },
   "dependencies": {
+    "@prisma/client": "5.22.0",
     "next": "14.2.5",
+    "next-auth": "5.0.0-beta.29",
+    "@auth/prisma-adapter": "^2.1.0",
+    "nodemailer": "^6.9.11",
+    "meilisearch": "^0.40.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "zod": "^3.23.8"
@@ -47,6 +53,7 @@
     "prettier-plugin-tailwindcss": "^0.6.5",
     "prisma": "^5.16.1",
     "tailwindcss": "^3.4.7",
+    "tsx": "^4.7.1",
     "typescript": "5.5.4",
     "vitest": "^2.0.5"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,24 @@ importers:
 
   .:
     dependencies:
+      '@auth/prisma-adapter':
+        specifier: ^2.1.0
+        version: 2.10.0(@prisma/client@5.22.0(prisma@5.22.0))(nodemailer@6.10.1)
+      '@prisma/client':
+        specifier: 5.22.0
+        version: 5.22.0(prisma@5.22.0)
+      meilisearch:
+        specifier: ^0.40.0
+        version: 0.40.0
       next:
         specifier: 14.2.5
         version: 14.2.5(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next-auth:
+        specifier: 5.0.0-beta.29
+        version: 5.0.0-beta.29(next@14.2.5(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@6.10.1)(react@18.3.1)
+      nodemailer:
+        specifier: ^6.9.11
+        version: 6.10.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -81,6 +96,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.7
         version: 3.4.17
+      tsx:
+        specifier: ^4.7.1
+        version: 4.20.5
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -93,6 +111,25 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@auth/core@0.40.0':
+    resolution: {integrity: sha512-n53uJE0RH5SqZ7N1xZoMKekbHfQgjd0sAEyUbE+IYJnmuQkbvuZnXItCU7d+i7Fj8VGOgqvNO7Mw4YfBTlZeQw==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^6.8.0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
+  '@auth/prisma-adapter@2.10.0':
+    resolution: {integrity: sha512-EliOQoTjGK87jWWqnJvlQjbR4PjQZQqtwRwPAe108WwT9ubuuJJIrL68aNnQr4hFESz6P7SEX2bZy+y2yL37Gw==}
+    peerDependencies:
+      '@prisma/client': '>=2.26.0 || >=3 || >=4 || >=5 || >=6'
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -186,9 +223,21 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.25.9':
+    resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.9':
+    resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -198,9 +247,21 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.25.9':
+    resolution: {integrity: sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.9':
+    resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -210,9 +271,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.25.9':
+    resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.9':
+    resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -222,9 +295,21 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.25.9':
+    resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.9':
+    resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -234,9 +319,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.25.9':
+    resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.9':
+    resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -246,9 +343,21 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.9':
+    resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.9':
+    resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -258,9 +367,21 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.9':
+    resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.9':
+    resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -270,9 +391,21 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.9':
+    resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.9':
+    resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -282,11 +415,35 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.9':
+    resolution: {integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.9':
+    resolution: {integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
@@ -294,9 +451,27 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.25.9':
+    resolution: {integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.9':
+    resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -306,15 +481,33 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.25.9':
+    resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.9':
+    resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.9':
+    resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -445,6 +638,9 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@panva/hkdf@1.2.1':
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -453,6 +649,15 @@ packages:
     resolution: {integrity: sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@prisma/client@5.22.0':
+    resolution: {integrity: sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==}
+    engines: {node: '>=16.13'}
+    peerDependencies:
+      prisma: '*'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
 
   '@prisma/debug@5.22.0':
     resolution: {integrity: sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==}
@@ -1092,6 +1297,9 @@ packages:
       typescript:
         optional: true
 
+  cross-fetch@3.2.0:
+    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1245,6 +1453,11 @@ packages:
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.25.9:
+    resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escalade@3.2.0:
@@ -1787,6 +2000,9 @@ packages:
     resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
     hasBin: true
 
+  jose@6.0.13:
+    resolution: {integrity: sha512-Yms4GpbmdANamS51kKK6w4hRlKx8KTxbWyAAKT/MhUMtqbIqh5mb2HjhTNUbk7TFL8/MBB5zWSDohL7ed4k/UA==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1907,6 +2123,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  meilisearch@0.40.0:
+    resolution: {integrity: sha512-BoRhQMr2mBFLEeCfsvPluksGb01IaOiWvV3Deu3iEY+yYJ4jdGTu+IQi5FCjKlNQ7/TMWSN2XUToSgvH1tj0BQ==}
+
   meow@12.1.1:
     resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
     engines: {node: '>=16.10'}
@@ -1967,6 +2186,22 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  next-auth@5.0.0-beta.29:
+    resolution: {integrity: sha512-Ukpnuk3NMc/LiOl32njZPySk7pABEzbjhMUFd5/n10I0ZNC7NCuVv8IY2JgbDek2t/PUOifQEoUiOOTLy4os5A==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      next: ^14.0.0-0 || ^15.0.0-0
+      nodemailer: ^6.6.5
+      react: ^18.2.0 || ^19.0.0-0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
   next@14.2.5:
     resolution: {integrity: sha512-0f8aRfBVL+mpzfBjYfQuLWh2WyAwtJXCRfkPF4UJ5qd2YwrHczsrSzXU4tRMV0OAxR8ZJZWPFn6uhSC56UTsLA==}
     engines: {node: '>=18.17.0'}
@@ -1985,8 +2220,21 @@ packages:
       sass:
         optional: true
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+
+  nodemailer@6.10.1:
+    resolution: {integrity: sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==}
+    engines: {node: '>=6.0.0'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -1999,6 +2247,9 @@ packages:
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  oauth4webapi@3.7.0:
+    resolution: {integrity: sha512-Q52wTPUWPsVLVVmTViXPQFMW2h2xv2jnDGxypjpelCFKaOjLsm7AxYuOk1oQgFm95VNDbuggasu9htXrz6XwKw==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2202,6 +2453,14 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  preact-render-to-string@6.5.11:
+    resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
+    peerDependencies:
+      preact: '>=10'
+
+  preact@10.24.3:
+    resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -2607,6 +2866,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   ts-api-utils@1.4.3:
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
     engines: {node: '>=16'}
@@ -2627,6 +2889,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.20.5:
+    resolution: {integrity: sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2744,6 +3011,12 @@ packages:
       jsdom:
         optional: true
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -2820,6 +3093,25 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@auth/core@0.40.0(nodemailer@6.10.1)':
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      jose: 6.0.13
+      oauth4webapi: 3.7.0
+      preact: 10.24.3
+      preact-render-to-string: 6.5.11(preact@10.24.3)
+    optionalDependencies:
+      nodemailer: 6.10.1
+
+  '@auth/prisma-adapter@2.10.0(@prisma/client@5.22.0(prisma@5.22.0))(nodemailer@6.10.1)':
+    dependencies:
+      '@auth/core': 0.40.0(nodemailer@6.10.1)
+      '@prisma/client': 5.22.0(prisma@5.22.0)
+    transitivePeerDependencies:
+      - '@simplewebauthn/browser'
+      - '@simplewebauthn/server'
+      - nodemailer
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -2958,70 +3250,148 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.9':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.9':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.25.9':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.25.9':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.9':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.9':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.9':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.9':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.9':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.9':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.9':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.9':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.9':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.9':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.9':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.9':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    optional: true
+
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.9':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    optional: true
+
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.9':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.25.9':
+    optional: true
+
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.9':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.9':
     optional: true
 
   '@eslint-community/eslint-utils@4.7.0(eslint@8.57.1)':
@@ -3136,12 +3506,18 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@panva/hkdf@1.2.1': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
   '@playwright/test@1.55.0':
     dependencies:
       playwright: 1.55.0
+
+  '@prisma/client@5.22.0(prisma@5.22.0)':
+    optionalDependencies:
+      prisma: 5.22.0
 
   '@prisma/debug@5.22.0': {}
 
@@ -3793,6 +4169,12 @@ snapshots:
     optionalDependencies:
       typescript: 5.5.4
 
+  cross-fetch@3.2.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -4021,6 +4403,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.21.5
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.25.9:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.9
+      '@esbuild/android-arm': 0.25.9
+      '@esbuild/android-arm64': 0.25.9
+      '@esbuild/android-x64': 0.25.9
+      '@esbuild/darwin-arm64': 0.25.9
+      '@esbuild/darwin-x64': 0.25.9
+      '@esbuild/freebsd-arm64': 0.25.9
+      '@esbuild/freebsd-x64': 0.25.9
+      '@esbuild/linux-arm': 0.25.9
+      '@esbuild/linux-arm64': 0.25.9
+      '@esbuild/linux-ia32': 0.25.9
+      '@esbuild/linux-loong64': 0.25.9
+      '@esbuild/linux-mips64el': 0.25.9
+      '@esbuild/linux-ppc64': 0.25.9
+      '@esbuild/linux-riscv64': 0.25.9
+      '@esbuild/linux-s390x': 0.25.9
+      '@esbuild/linux-x64': 0.25.9
+      '@esbuild/netbsd-arm64': 0.25.9
+      '@esbuild/netbsd-x64': 0.25.9
+      '@esbuild/openbsd-arm64': 0.25.9
+      '@esbuild/openbsd-x64': 0.25.9
+      '@esbuild/openharmony-arm64': 0.25.9
+      '@esbuild/sunos-x64': 0.25.9
+      '@esbuild/win32-arm64': 0.25.9
+      '@esbuild/win32-ia32': 0.25.9
+      '@esbuild/win32-x64': 0.25.9
 
   escalade@3.2.0: {}
 
@@ -4651,6 +5062,8 @@ snapshots:
 
   jiti@2.5.1: {}
 
+  jose@6.0.13: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.0:
@@ -4771,6 +5184,12 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  meilisearch@0.40.0:
+    dependencies:
+      cross-fetch: 3.2.0
+    transitivePeerDependencies:
+      - encoding
+
   meow@12.1.1: {}
 
   merge-stream@2.0.0: {}
@@ -4816,6 +5235,14 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  next-auth@5.0.0-beta.29(next@14.2.5(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@6.10.1)(react@18.3.1):
+    dependencies:
+      '@auth/core': 0.40.0(nodemailer@6.10.1)
+      next: 14.2.5(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      nodemailer: 6.10.1
+
   next@14.2.5(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.5
@@ -4842,7 +5269,13 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-releases@2.0.19: {}
+
+  nodemailer@6.10.1: {}
 
   normalize-path@3.0.0: {}
 
@@ -4851,6 +5284,8 @@ snapshots:
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
+
+  oauth4webapi@3.7.0: {}
 
   object-assign@4.1.1: {}
 
@@ -5039,6 +5474,12 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  preact-render-to-string@6.5.11(preact@10.24.3):
+    dependencies:
+      preact: 10.24.3
+
+  preact@10.24.3: {}
 
   prelude-ls@1.2.1: {}
 
@@ -5452,6 +5893,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tr46@0.0.3: {}
+
   ts-api-utils@1.4.3(typescript@5.5.4):
     dependencies:
       typescript: 5.5.4
@@ -5470,6 +5913,13 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.20.5:
+    dependencies:
+      esbuild: 0.25.9
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:
@@ -5620,6 +6070,13 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,9 +7,164 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-// Minimal model so prisma generate works cleanly
-model User {
-  id        String   @id @default(cuid())
-  email     String   @unique
-  createdAt DateTime @default(now())
+enum Role {
+  ADMIN
+  EDITOR
+  USER
 }
+
+enum StoryStatus {
+  DRAFT
+  PUBLISHED
+}
+
+model User {
+  id            String   @id @default(cuid())
+  name          String?
+  email         String   @unique
+  emailVerified DateTime?
+  image         String?
+  role          Role     @default(USER)
+  accounts      Account[]
+  sessions      Session[]
+  readingProgress ReadingProgress[]
+  events        Event[]
+  experimentAssignments UserExperimentAssignment[]
+}
+
+model Account {
+  id                String @id @default(cuid())
+  userId            String
+  type              String
+  provider          String
+  providerAccountId String
+  refresh_token     String?
+  access_token      String?
+  expires_at        Int?
+  token_type        String?
+  scope             String?
+  id_token          String?
+  session_state     String?
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+}
+
+model Session {
+  id           String   @id @default(cuid())
+  sessionToken String   @unique
+  userId       String
+  expires      DateTime
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model VerificationToken {
+  identifier String
+  token      String @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
+}
+
+model Story {
+  id            String      @id @default(cuid())
+  slug          String      @unique
+  title         String
+  description   String
+  tags          String[]    @default([])
+  ageMin        Int
+  ageMax        Int
+  isInteractive Boolean     @default(false)
+  status        StoryStatus @default(DRAFT)
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
+  publishedAt   DateTime?
+  body          StoryBody?
+  interactiveNodes InteractiveNode[]
+  readingProgress ReadingProgress[]
+  freeRotation   FreeRotation?
+}
+
+model StoryBody {
+  storyId        String @id
+  lang           String
+  html           String
+  readingTimeSec Int?
+  story          Story  @relation(fields: [storyId], references: [id], onDelete: Cascade)
+}
+
+model InteractiveNode {
+  id        String @id @default(cuid())
+  storyId   String
+  title     String
+  bodyHtml  String
+  story     Story   @relation(fields: [storyId], references: [id], onDelete: Cascade)
+  choices   InteractiveChoice[] @relation("FromNode")
+  incoming  InteractiveChoice[] @relation("ToNode")
+
+  @@index([storyId])
+}
+
+model InteractiveChoice {
+  id         String @id @default(cuid())
+  fromNodeId String
+  label      String
+  toNodeId   String
+
+  fromNode InteractiveNode @relation("FromNode", fields: [fromNodeId], references: [id], onDelete: Cascade)
+  toNode   InteractiveNode @relation("ToNode", fields: [toNodeId], references: [id], onDelete: Cascade)
+
+  @@index([fromNodeId])
+  @@index([toNodeId])
+}
+
+model ReadingProgress {
+  userId    String
+  storyId   String
+  lastPos   String
+  updatedAt DateTime @default(now())
+
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  story Story @relation(fields: [storyId], references: [id], onDelete: Cascade)
+
+  @@id([userId, storyId])
+}
+
+model Event {
+  id     String   @id @default(cuid())
+  userId String?
+  name   String
+  props  Json
+  ts     DateTime @default(now())
+
+  user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  @@index([userId])
+  @@index([name, ts])
+}
+
+model ExperimentConfig {
+  key       String @id
+  variants  Json
+  updatedAt DateTime @updatedAt
+}
+
+model UserExperimentAssignment {
+  userId  String
+  key     String
+  variant String
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([userId, key])
+}
+
+model FreeRotation {
+  id       String @id @default(cuid())
+  storyId  String @unique
+  monthKey String
+  priority Int    @default(0)
+  story    Story  @relation(fields: [storyId], references: [id], onDelete: Cascade)
+}
+

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,83 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const adminEmail = process.env.SEED_ADMIN_EMAIL || "admin@example.com";
+  await prisma.user.upsert({
+    where: { email: adminEmail },
+    update: { role: "ADMIN" },
+    create: { email: adminEmail, role: "ADMIN" },
+  });
+
+  const s1 = await prisma.story.upsert({
+    where: { slug: "prikazka-za-lisicata" },
+    update: {},
+    create: {
+      slug: "prikazka-za-lisicata",
+      title: "Приказка за Лисицата",
+      description: "Топла, кратка приказка за деца 3–8",
+      tags: ["животни", "приятелство"],
+      ageMin: 3,
+      ageMax: 8,
+      status: "DRAFT",
+      body: {
+        create: {
+          lang: "bg",
+          html: "<p>Имало едно време една умна лисица...</p>",
+          readingTimeSec: 120,
+        },
+      },
+    },
+  });
+
+  const s2 = await prisma.story.upsert({
+    where: { slug: "interaktivna-prikazka-demo" },
+    update: {},
+    create: {
+      slug: "interaktivna-prikazka-demo",
+      title: "Интерактивна Приказка (Демо)",
+      description: "Една изборна история с 3 възела",
+      tags: ["интерактивна", "демо"],
+      isInteractive: true,
+      status: "DRAFT",
+    },
+  });
+
+  const n1 = await prisma.interactiveNode.create({
+    data: {
+      storyId: s2.id,
+      bodyHtml: "<p>Начало: лява или дясна пътека?</p>",
+      title: "start",
+    },
+  });
+  const n2 = await prisma.interactiveNode.create({
+    data: {
+      storyId: s2.id,
+      bodyHtml: "<p>Ляво: намираш приятел.</p>",
+      title: "left",
+    },
+  });
+  const n3 = await prisma.interactiveNode.create({
+    data: {
+      storyId: s2.id,
+      bodyHtml: "<p>Дясно: научаваш урок.</p>",
+      title: "right",
+    },
+  });
+  await prisma.interactiveChoice.createMany({
+    data: [
+      { fromNodeId: n1.id, toNodeId: n2.id, label: "Ляво" },
+      { fromNodeId: n1.id, toNodeId: n3.id, label: "Дясно" },
+    ],
+  });
+
+  console.log("Seed complete:", { adminEmail, s1: s1.slug, s2: s2.slug });
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => prisma.$disconnect());

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from "@playwright/test";
+
+test("admin requires auth", async ({ page }) => {
+  const res = await page.goto("/admin");
+  expect(res?.status()).toBe(200);
+  await expect(page).toHaveURL(/\/auth\/signin/);
+});

--- a/tests/e2e/basic.spec.ts
+++ b/tests/e2e/basic.spec.ts
@@ -11,3 +11,8 @@ test("health endpoint", async ({ request }) => {
   const json = await res.json();
   expect(json.ok).toBe(true);
 });
+
+test("search endpoint", async ({ request }) => {
+  const res = await request.get("/api/search?q=demo");
+  expect(res.status()).toBe(200);
+});

--- a/tests/unit/slug.spec.ts
+++ b/tests/unit/slug.spec.ts
@@ -1,0 +1,8 @@
+import { toSlug } from "../../lib/slug";
+import { describe, it, expect } from "vitest";
+
+describe("toSlug", () => {
+  it("normalizes text", () => {
+    expect(toSlug(" Приказка за Лисицата! ")).toBe("prikazka-za-lisicata");
+  });
+});

--- a/tests/unit/validators.spec.ts
+++ b/tests/unit/validators.spec.ts
@@ -1,0 +1,16 @@
+import { StoryUpsertSchema } from "../../lib/validators";
+import { describe, it, expect } from "vitest";
+
+describe("StoryUpsertSchema", () => {
+  it("parses basic story", () => {
+    const parsed = StoryUpsertSchema.parse({
+      title: "Test Story",
+      slug: "test-story",
+      description: "This is a description with more than ten chars",
+      tags: "a, b",
+      ageMin: 3,
+      ageMax: 8,
+    });
+    expect(parsed.tags).toEqual(["a", "b"]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,6 @@
       }
     ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "types", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,0 +1,20 @@
+import "next-auth";
+import "next-auth/jwt";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id?: string;
+      name?: string | null;
+      email?: string | null;
+      image?: string | null;
+      role: "ADMIN" | "EDITOR" | "USER";
+    };
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    role?: "ADMIN" | "EDITOR" | "USER";
+  }
+}


### PR DESCRIPTION
## Summary
- add NextAuth email magic link auth and admin pages
- integrate MeiliSearch and local storage adapter
- scaffold Prisma schema, seed script, and tests

## Testing
- `docker compose -f docker-compose.services.yml up -d` *(fails: command not found)*
- `pnpm dlx prisma migrate dev --name init_core` *(fails: Can't reach database server at `localhost:5432`)*
- `pnpm dlx prisma generate`
- `pnpm db:seed` *(fails: Command failed with exit code 134)*
- `pnpm test`
- `pnpm e2e` *(fails: Could not find a production build)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3e3e3a8c832cb16bfc0bff1a1250