### PR TITLE
fix: export handlers correctly

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,1 +1,1 @@
-export { handlers as GET, handlers as POST } from "@/auth";
+export { GET, POST } from "@/auth";

--- a/auth.ts
+++ b/auth.ts
@@ -31,4 +31,9 @@ export const authConfig: NextAuthConfig = {
   secret: process.env.AUTH_SECRET,
 };
 
-export const { handlers, auth, signIn, signOut } = NextAuth(authConfig);
+export const {
+  handlers: { GET, POST },
+  auth,
+  signIn,
+  signOut,
+} = NextAuth(authConfig);


### PR DESCRIPTION
## Summary
- fix NextAuth handler exports
- wire auth route to GET and POST handlers

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build` (fails: The provided host is not valid)

------
https://chatgpt.com/codex/tasks/task_e_68ab423c4810832c98ee0c2ea870f127