### PR TITLE
Handle missing external service config during build

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -8,13 +8,16 @@ import type { User } from "@prisma/client";
 export const authConfig: NextAuthConfig = {
   adapter: PrismaAdapter(prisma),
   session: { strategy: "jwt" },
-  providers: [
-    EmailProvider({
-      server: process.env.EMAIL_SERVER!,
-      from: process.env.EMAIL_FROM!,
-      maxAge: 10 * 60,
-    }),
-  ],
+  providers:
+    process.env.EMAIL_SERVER && process.env.EMAIL_FROM
+      ? [
+          EmailProvider({
+            server: process.env.EMAIL_SERVER,
+            from: process.env.EMAIL_FROM,
+            maxAge: 10 * 60,
+          }),
+        ]
+      : [],
   callbacks: {
     async jwt({ token, user }) {
       if (user) (token as JWT).role = (user as User).role ?? "USER";

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,13 +1,23 @@
 import { MeiliSearch } from "meilisearch";
 import type { Story } from "@prisma/client";
+import type { Index } from "meilisearch";
 
-const client = new MeiliSearch({
-  host: process.env.MEILI_HOST!,
-  apiKey: process.env.MEILI_API_KEY,
-});
+type SearchResult = Awaited<ReturnType<Index["search"]>>;
+
 const indexName = process.env.MEILI_INDEX_STORIES || "stories";
 
-export async function ensureStoryIndex() {
+function getClient() {
+  const host = process.env.MEILI_HOST;
+  if (!host) return null;
+  return new MeiliSearch({
+    host,
+    apiKey: process.env.MEILI_API_KEY,
+  });
+}
+
+export async function ensureStoryIndex(): Promise<Index | null> {
+  const client = getClient();
+  if (!client) return null;
   await client.createIndex(indexName, { primaryKey: "id" }).catch(() => {});
   const index = client.index(indexName);
   await index.updateSettings({
@@ -22,6 +32,7 @@ export async function upsertStoryIndex(
   s: Story & { body?: { html: string | null } | null },
 ) {
   const index = await ensureStoryIndex();
+  if (!index) return;
   await index.addDocuments([
     {
       id: s.id,
@@ -37,7 +48,8 @@ export async function upsertStoryIndex(
   ]);
 }
 
-export async function searchStories(q: string) {
+export async function searchStories(q: string): Promise<SearchResult> {
   const index = await ensureStoryIndex();
+  if (!index) return { hits: [] } as SearchResult;
   return index.search(q, { limit: 10 });
 }


### PR DESCRIPTION
## Summary
- avoid initializing MeiliSearch client when env vars are missing
- skip Email provider when SMTP env is not configured

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68ab53e036c4832cb408ab567d673748