### PR TITLE
fix: guard admin story query behind database url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -2,9 +2,11 @@ import { prisma } from "@/lib/prisma";
 import Link from "next/link";
 
 export default async function AdminPage() {
-  const stories = await prisma.story.findMany({
-    orderBy: { updatedAt: "desc" },
-  });
+  const stories = process.env.DATABASE_URL
+    ? await prisma.story.findMany({
+        orderBy: { updatedAt: "desc" },
+      })
+    : [];
   return (
     <main className="mx-auto max-w-4xl p-6">
       <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- query stories only when `DATABASE_URL` exists
- expose `DATABASE_URL` env in GitHub Actions

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build` *(fails: Event handlers cannot be passed to Client Component props)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5718a0c0832c96214cc1d166e066