### PR TITLE
refactor: move slug input to client component

### DIFF
--- a/app/admin/stories/new/SlugInput.tsx
+++ b/app/admin/stories/new/SlugInput.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { toSlug } from "@/lib/slug";
+
+export default function SlugInput() {
+  return (
+    <input
+      name="slug"
+      placeholder="slug"
+      className="w-full rounded border p-2"
+      onChange={(e) => (e.currentTarget.value = toSlug(e.currentTarget.value))}
+    />
+  );
+}

--- a/app/admin/stories/new/page.tsx
+++ b/app/admin/stories/new/page.tsx
@@ -1,5 +1,5 @@
 import { upsertStoryAction } from "@/app/admin/actions";
-import { toSlug } from "@/lib/slug";
+import SlugInput from "./SlugInput";
 
 export default function NewStory() {
   return (
@@ -12,14 +12,7 @@ export default function NewStory() {
           className="w-full rounded border p-2"
           required
         />
-        <input
-          name="slug"
-          placeholder="slug"
-          className="w-full rounded border p-2"
-          onChange={(e) =>
-            (e.currentTarget.value = toSlug(e.currentTarget.value))
-          }
-        />
+        <SlugInput />
         <textarea
           name="description"
           placeholder="Short description"


### PR DESCRIPTION
## Summary
- extract slug slug input into a dedicated client component
- use new slug input in new story page

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab59208110832cbad6cd1177ace139