### PR TITLE
fix: use edge-compatible auth middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,12 +1,12 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { auth } from "@/auth";
+import { getToken } from "next-auth/jwt";
 
 export async function middleware(req: NextRequest) {
   const url = req.nextUrl;
   if (url.pathname.startsWith("/admin")) {
-    const session = await auth();
-    const role = (session?.user as { role?: string } | undefined)?.role;
+    const token = await getToken({ req });
+    const role = (token as { role?: string } | null)?.role;
     if (!role || (role !== "ADMIN" && role !== "EDITOR")) {
       const signInUrl = new URL("/auth/signin", url);
       return NextResponse.redirect(signInUrl);


### PR DESCRIPTION
## Summary
- replace middleware auth() call with edge-safe token check

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e` *(fails: Process from config.webServer was not able to start due to build errors about event handlers passed to Client Component props)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5ab97cf0832c9e54eaa796233ca1