### PR TITLE
fix: use JWT token in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,12 +1,12 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { auth } from "@/auth";
+import { getToken } from "next-auth/jwt";
 
 export async function middleware(req: NextRequest) {
   const url = req.nextUrl;
   if (url.pathname.startsWith("/admin")) {
-    const session = await auth();
-    const role = (session?.user as { role?: string } | undefined)?.role;
+    const token = await getToken({ req });
+    const role = (token as { role?: string } | null)?.role;
     if (!role || (role !== "ADMIN" && role !== "EDITOR")) {
       const signInUrl = new URL("/auth/signin", url);
       return NextResponse.redirect(signInUrl);


### PR DESCRIPTION
## Summary
- avoid importing server-only auth in middleware by using next-auth JWT token

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm e2e`


------
https://chatgpt.com/codex/tasks/task_e_68ab5e51ff08832cb1322bb74eeb5373