### PR TITLE
fix: handle auth in middleware and search errors

### DIFF
--- a/lib/search.ts
+++ b/lib/search.ts
@@ -38,6 +38,10 @@ export async function upsertStoryIndex(
 }
 
 export async function searchStories(q: string) {
-  const index = await ensureStoryIndex();
-  return index.search(q, { limit: 10 });
+  try {
+    const index = await ensureStoryIndex();
+    return await index.search(q, { limit: 10 });
+  } catch {
+    return { hits: [] };
+  }
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,12 +1,12 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { auth } from "@/auth";
+import { getToken } from "next-auth/jwt";
 
 export async function middleware(req: NextRequest) {
   const url = req.nextUrl;
   if (url.pathname.startsWith("/admin")) {
-    const session = await auth();
-    const role = session?.user.role;
+    const token = await getToken({ req });
+    const role = (token as { role?: string } | null)?.role;
     if (!role || (role !== "ADMIN" && role !== "EDITOR")) {
       const signInUrl = new URL("/auth/signin", url);
       return NextResponse.redirect(signInUrl);


### PR DESCRIPTION
## Summary
- use JWT-based role check in middleware instead of server-side auth
- return empty hits when MeiliSearch is unavailable

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6d8179b8832c9b8f7ef37a03cf8e