### PR TITLE
fix: pass auth secret to middleware token

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -5,7 +5,7 @@ import { getToken } from "next-auth/jwt";
 export async function middleware(req: NextRequest) {
   const url = req.nextUrl;
   if (url.pathname.startsWith("/admin")) {
-    const token = await getToken({ req });
+    const token = await getToken({ req, secret: process.env.AUTH_SECRET });
     const role = (token as { role?: string } | null)?.role;
     if (!role || (role !== "ADMIN" && role !== "EDITOR")) {
       const signInUrl = new URL("/auth/signin", url);


### PR DESCRIPTION
## Summary
- pass AUTH_SECRET to getToken in middleware to avoid missing secret errors

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ab8371bc88832c8d438eb76ccc0177