### PR TITLE
fix(admin): add client-side validation for story forms

### DIFF
--- a/app/admin/stories/[id]/page.tsx
+++ b/app/admin/stories/[id]/page.tsx
@@ -23,17 +23,27 @@ export default async function EditStory({
           name="title"
           defaultValue={s.title}
           className="w-full rounded border p-2"
+          required
+          minLength={3}
+          maxLength={120}
         />
         <input
           name="slug"
           defaultValue={s.slug}
           className="w-full rounded border p-2"
+          required
+          minLength={3}
+          maxLength={140}
+          pattern="[a-z0-9-]+"
         />
         <textarea
           name="description"
           defaultValue={s.description}
           className="w-full rounded border p-2"
           rows={3}
+          required
+          minLength={10}
+          maxLength={500}
         />
         <input
           name="tags"
@@ -46,12 +56,18 @@ export default async function EditStory({
             type="number"
             defaultValue={s.ageMin}
             className="w-24 rounded border p-2"
+            min={3}
+            max={12}
+            required
           />
           <input
             name="ageMax"
             type="number"
             defaultValue={s.ageMax}
             className="w-24 rounded border p-2"
+            min={3}
+            max={12}
+            required
           />
         </div>
         <label className="flex items-center gap-2">

--- a/app/admin/stories/new/SlugInput.tsx
+++ b/app/admin/stories/new/SlugInput.tsx
@@ -8,6 +8,10 @@ export default function SlugInput() {
       name="slug"
       placeholder="slug"
       className="w-full rounded border p-2"
+      minLength={3}
+      maxLength={140}
+      pattern="[a-z0-9-]+"
+      required
       onChange={(e) => (e.currentTarget.value = toSlug(e.currentTarget.value))}
     />
   );

--- a/app/admin/stories/new/page.tsx
+++ b/app/admin/stories/new/page.tsx
@@ -11,6 +11,8 @@ export default function NewStory() {
           placeholder="Title"
           className="w-full rounded border p-2"
           required
+          minLength={3}
+          maxLength={120}
         />
         <SlugInput />
         <textarea
@@ -18,6 +20,9 @@ export default function NewStory() {
           placeholder="Short description"
           className="w-full rounded border p-2"
           rows={3}
+          required
+          minLength={10}
+          maxLength={500}
         />
         <input
           name="tags"
@@ -32,6 +37,7 @@ export default function NewStory() {
             min={3}
             max={12}
             className="w-24 rounded border p-2"
+            required
           />
           <input
             name="ageMax"
@@ -40,6 +46,7 @@ export default function NewStory() {
             min={3}
             max={12}
             className="w-24 rounded border p-2"
+            required
           />
         </div>
         <label className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- add validation constraints to new story form inputs
- enforce same constraints when editing stories

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ab85af79e8832c9731495aae47e07a