### PR TITLE
fix: serve assets from uploads

### DIFF
--- a/app/api/assets/[...key]/route.ts
+++ b/app/api/assets/[...key]/route.ts
@@ -2,17 +2,32 @@ import fs from "fs/promises";
 import path from "path";
 import { NextResponse } from "next/server";
 
-const baseDir = process.env.ASSETS_DIR || "./uploads";
+const uploadsRoot = process.env.ASSETS_DIR || "./uploads";
+const baseDir = path.isAbsolute(uploadsRoot)
+  ? uploadsRoot
+  : path.join(process.cwd(), uploadsRoot);
 
 export async function GET(
   _req: Request,
   { params }: { params: { key: string[] } },
 ) {
   const filePath = path.join(baseDir, ...params.key);
+
+  console.log("asset request", {
+    cwd: process.cwd(),
+    uploadsRoot,
+    filePath,
+  });
+
   try {
     const file = await fs.readFile(filePath);
     return new NextResponse(file);
-  } catch {
-    return new NextResponse("Not found", { status: 404 });
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return new NextResponse("Not found", { status: 404 });
+    }
+
+    console.error(err);
+    return new NextResponse("Error", { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- resolve uploads directory to absolute path and add debug logging
- handle missing assets with ENOENT check

## Testing
- `pnpm lint`
- `pnpm test`
- `curl -i http://localhost:3000/api/assets/covers/demo.txt`
- `curl -i http://localhost:3000/api/assets/covers/missing.txt`


------
https://chatgpt.com/codex/tasks/task_e_68ab8c62c104832caf0285ac01359ba0