### PR TITLE
fix: encode LocalStorage URL path segments

### DIFF
--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -17,7 +17,7 @@ export const LocalStorage: StorageAdapter = {
     await fs.writeFile(p, data);
   },
   getUrl(key) {
-    return `${publicBase}/${encodeURIComponent(key)}`;
+    return `${publicBase}/${key.split("/").map(encodeURIComponent).join("/")}`;
   },
   async deleteObject(key) {
     const p = path.join(baseDir, key);


### PR DESCRIPTION
## Summary
- encode each path segment in `LocalStorage.getUrl` separately

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab916f4228832caedf03ecb53f834b