### PR TITLE
fix: prevent asset path traversal

### DIFF
--- a/app/api/assets/[...key]/route.ts
+++ b/app/api/assets/[...key]/route.ts
@@ -19,6 +19,11 @@ export async function GET(
     filePath,
   });
 
+  const relative = path.relative(baseDir, filePath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    return new NextResponse("Forbidden", { status: 403 });
+  }
+
   try {
     const file = await fs.readFile(filePath);
     return new NextResponse(file);


### PR DESCRIPTION
## Summary
- forbid asset API requests from escaping base directory

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab92f22d90832cb78bb43a2ee0424d