### PR TITLE
fix: resolve asset directory from project root

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ MEILI_HOST=http://localhost:7700
 MEILI_API_KEY=masterKey
 MEILI_INDEX_STORIES=stories
 
+# Directory where uploaded assets are stored. Can be an absolute path or
+# relative to the project root.
 ASSETS_DIR=./uploads
 ASSETS_PUBLIC_BASE=/api/assets
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ test-results
 tsconfig.tsbuildinfo
 v8-compile-cache-*
 .DS_Store
+
+# uploaded assets
+uploads/*
+!uploads/.gitkeep

--- a/app/api/assets/[...key]/route.ts
+++ b/app/api/assets/[...key]/route.ts
@@ -2,10 +2,11 @@ import fs from "fs/promises";
 import path from "path";
 import { NextResponse } from "next/server";
 
-const uploadsRoot = process.env.ASSETS_DIR || "./uploads";
-const baseDir = path.isAbsolute(uploadsRoot)
-  ? uploadsRoot
-  : path.join(process.cwd(), uploadsRoot);
+// Resolve the directory that stores uploaded assets. This path can be
+// configured via the `ASSETS_DIR` environment variable. When not provided it
+// falls back to `<project root>/uploads`.
+const uploadsRoot = process.env.ASSETS_DIR ?? "uploads";
+const baseDir = path.resolve(process.cwd(), uploadsRoot);
 
 export async function GET(
   _req: Request,
@@ -16,6 +17,7 @@ export async function GET(
   console.log("asset request", {
     cwd: process.cwd(),
     uploadsRoot,
+    baseDir,
     filePath,
   });
 


### PR DESCRIPTION
## Summary
- resolve `ASSETS_DIR` to an absolute path based on project root
- document asset directory configuration and ignore uploaded files

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab94414920832cbb36419a0b415bc0