### PR TITLE
fix: resolve uploads directory

### DIFF
--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -7,20 +7,23 @@ export interface StorageAdapter {
   deleteObject(key: string): Promise<void>;
 }
 
-const baseDir = process.env.ASSETS_DIR || "./uploads";
+const baseDir = path.resolve(
+  process.cwd(),
+  process.env.ASSETS_DIR ?? "uploads",
+);
 const publicBase = process.env.ASSETS_PUBLIC_BASE || "/api/assets";
 
 export const LocalStorage: StorageAdapter = {
   async putObject(key, data) {
-    const p = path.join(baseDir, key);
-    await fs.mkdir(path.dirname(p), { recursive: true });
-    await fs.writeFile(p, data);
+    const filePath = path.join(baseDir, key);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, data);
   },
   getUrl(key) {
     return `${publicBase}/${key.split("/").map(encodeURIComponent).join("/")}`;
   },
   async deleteObject(key) {
-    const p = path.join(baseDir, key);
-    await fs.rm(p, { force: true });
+    const filePath = path.join(baseDir, key);
+    await fs.rm(filePath, { force: true });
   },
 };

--- a/tests/unit/assets.spec.ts
+++ b/tests/unit/assets.spec.ts
@@ -1,0 +1,35 @@
+import fs from "fs/promises";
+import path from "path";
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+
+describe("LocalStorage and /api/assets", () => {
+  const testUploads = "test-uploads";
+  const uploadsPath = path.resolve(process.cwd(), testUploads);
+
+  beforeAll(() => {
+    process.env.ASSETS_DIR = testUploads;
+  });
+
+  afterAll(async () => {
+    delete process.env.ASSETS_DIR;
+    await fs.rm(uploadsPath, { recursive: true, force: true });
+  });
+
+  it("operate on the same directory", async () => {
+    const { LocalStorage } = await import("../../lib/storage");
+    const { GET } = await import("../../app/api/assets/[...key]/route");
+
+    const key = "dir/file.txt";
+    const data = "hello";
+    await LocalStorage.putObject(key, Buffer.from(data));
+
+    const res = await GET(new Request("http://example.com"), {
+      params: { key: key.split("/") },
+    });
+    const body = await res.text();
+
+    expect(body).toBe(data);
+
+    await LocalStorage.deleteObject(key);
+  });
+});


### PR DESCRIPTION
## Summary
- resolve assets base directory using `path.resolve`
- verify LocalStorage and `/api/assets` use the same directory

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab99710f74832cbb3607adb4264fd1