### PR TITLE
feat: set asset content type

### DIFF
--- a/app/api/assets/[...key]/route.ts
+++ b/app/api/assets/[...key]/route.ts
@@ -1,6 +1,7 @@
 import fs from "fs/promises";
 import path from "path";
 import { NextResponse } from "next/server";
+import { lookup as getMimeType } from "mime-types";
 
 // Resolve the directory that stores uploaded assets. This path can be
 // configured via the `ASSETS_DIR` environment variable. When not provided it
@@ -28,7 +29,10 @@ export async function GET(
 
   try {
     const file = await fs.readFile(filePath);
-    return new NextResponse(file);
+    const mimeType = getMimeType(filePath) || "application/octet-stream";
+    return new NextResponse(file, {
+      headers: { "Content-Type": mimeType },
+    });
   } catch (err: unknown) {
     const error = err as NodeJS.ErrnoException;
     const code = error?.code;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@auth/prisma-adapter": "^2.1.0",
     "@prisma/client": "6.14.0",
     "meilisearch": "^0.40.0",
+    "mime-types": "^3.0.1",
     "next": "14.2.5",
     "next-auth": "5.0.0-beta.29",
     "nodemailer": "^6.9.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       meilisearch:
         specifier: ^0.40.0
         version: 0.40.0
+      mime-types:
+        specifier: ^3.0.1
+        version: 3.0.1
       next:
         specifier: 14.2.5
         version: 14.2.5(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2203,6 +2206,14 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.1:
+    resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
+    engines: {node: '>= 0.6'}
 
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
@@ -5367,6 +5378,12 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.1:
+    dependencies:
+      mime-db: 1.54.0
 
   mimic-fn@4.0.0: {}
 

--- a/tests/unit/assets.spec.ts
+++ b/tests/unit/assets.spec.ts
@@ -33,6 +33,38 @@ describe("LocalStorage and /api/assets", () => {
     await LocalStorage.deleteObject(key);
   });
 
+  it("sets Content-Type for .txt files", async () => {
+    const { LocalStorage } = await import("../../lib/storage");
+    const { GET } = await import("../../app/api/assets/[...key]/route");
+
+    const key = "file.txt";
+    await LocalStorage.putObject(key, Buffer.from("data"));
+
+    const res = await GET(new Request("http://example.com"), {
+      params: { key: key.split("/") },
+    });
+
+    expect(res.headers.get("Content-Type")).toBe("text/plain");
+
+    await LocalStorage.deleteObject(key);
+  });
+
+  it("sets Content-Type for .png files", async () => {
+    const { LocalStorage } = await import("../../lib/storage");
+    const { GET } = await import("../../app/api/assets/[...key]/route");
+
+    const key = "image.png";
+    await LocalStorage.putObject(key, Buffer.from("png"));
+
+    const res = await GET(new Request("http://example.com"), {
+      params: { key: key.split("/") },
+    });
+
+    expect(res.headers.get("Content-Type")).toBe("image/png");
+
+    await LocalStorage.deleteObject(key);
+  });
+
   it("returns 404 when file is missing", async () => {
     const { GET } = await import("../../app/api/assets/[...key]/route");
 


### PR DESCRIPTION
## Summary
- serve assets with appropriate Content-Type based on file extension
- add unit tests for content type on .txt and .png assets

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac84591328832c9ba31c5ad8dcd623