### PR TITLE
fix: add mime-types type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@commitlint/cli": "^19.4.0",
     "@commitlint/config-conventional": "^19.4.0",
     "@playwright/test": "^1.46.0",
+    "@types/mime-types": "^3.0.1",
     "@types/node": "^20.12.12",
     "@types/react": "^18.2.74",
     "@types/react-dom": "^18.2.24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@playwright/test':
         specifier: ^1.46.0
         version: 1.55.0
+      '@types/mime-types':
+        specifier: ^3.0.1
+        version: 3.0.1
       '@types/node':
         specifier: ^20.12.12
         version: 20.19.11
@@ -809,6 +812,9 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/mime-types@3.0.1':
+    resolution: {integrity: sha512-xRMsfuQbnRq1Ef+C+RKaENOxXX87Ygl38W1vDfPHRku02TgQr+Qd8iivLtAMcR0KF5/29xlnFihkTlbqFrGOVQ==}
 
   '@types/node@20.19.11':
     resolution: {integrity: sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==}
@@ -3744,6 +3750,8 @@ snapshots:
   '@types/estree@1.0.8': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/mime-types@3.0.1': {}
 
   '@types/node@20.19.11':
     dependencies:


### PR DESCRIPTION
## Summary
- add `@types/mime-types` to fix missing type declarations

## Testing
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac85bf1890832c9a5ffab807d4e013