### PR TITLE
Fix stripe webhook test mocks

### DIFF
--- a/tests/unit/stripeWebhook.spec.ts
+++ b/tests/unit/stripeWebhook.spec.ts
@@ -1,5 +1,5 @@
 import Stripe from "stripe";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, type Mock } from "vitest";
 import {
   handleStripeEvent,
   priceToPlan,
@@ -48,7 +48,7 @@ describe("priceToPlan", () => {
 describe("handleStripeEvent", () => {
   it("skips duplicate events", async () => {
     const deps = baseDeps();
-    deps.prisma.webhookReceipt.findUnique.mockResolvedValue({
+    (deps.prisma.webhookReceipt.findUnique as Mock).mockResolvedValue({
       id: "w1",
     } as unknown);
     const event = {


### PR DESCRIPTION
## Summary
- add Vitest Mock typing so stripe webhook tests can override mocked Prisma calls

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d3864210b0832cb0ca939b0964c8f4