### PR TITLE
Add mock Prisma client for e2e runs without DATABASE_URL

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,10 +1,25 @@
 import { PrismaClient } from "@prisma/client";
+import { createMockPrisma } from "./prismaMock";
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
 };
 
-export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+const hasDatabaseUrl = Boolean(process.env.DATABASE_URL);
+const useMockPrisma =
+  process.env.USE_MOCK_PRISMA === "1" || (!hasDatabaseUrl && process.env.CI);
+
+if (!hasDatabaseUrl && !useMockPrisma) {
+  throw new Error(
+    "DATABASE_URL is not defined. Set USE_MOCK_PRISMA=1 to run with the in-memory mock.",
+  );
+}
+
+const client =
+  globalForPrisma.prisma ??
+  (useMockPrisma ? createMockPrisma() : new PrismaClient());
+
+export const prisma = client;
 
 if (process.env.NODE_ENV !== "production") {
   globalForPrisma.prisma = prisma;

--- a/lib/prismaMock.ts
+++ b/lib/prismaMock.ts
@@ -1,0 +1,215 @@
+import { randomUUID } from "crypto";
+import type { PrismaClient } from "@prisma/client";
+
+type StoryBody = {
+  storyId: string;
+  html: string;
+  lang: string;
+};
+
+type MockStory = {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  tags: string[];
+  ageMin: number;
+  ageMax: number;
+  status: string;
+  createdAt: Date;
+  updatedAt: Date;
+  publishedAt: Date | null;
+  body: StoryBody | null;
+  audio: null;
+};
+
+type StoryInclude = {
+  body?: boolean;
+  audio?: boolean;
+};
+
+type UpsertArgs = {
+  where: { slug?: string; id?: string };
+  create: Record<string, unknown>;
+  update: Record<string, unknown>;
+  include?: StoryInclude;
+};
+
+type FindUniqueArgs = {
+  where: { slug?: string; id?: string };
+  include?: StoryInclude;
+};
+
+type DeleteManyArgs = {
+  where?: { storyId?: string };
+};
+
+type FreeRotationRecord = {
+  id: string;
+  storyId: string;
+  monthKey: string;
+  priority: number;
+};
+
+function cloneStory(story: MockStory, include?: StoryInclude) {
+  const clone: Record<string, unknown> = {
+    ...story,
+  };
+
+  if (include?.body) {
+    clone.body = story.body ? { ...story.body } : null;
+  } else {
+    delete clone.body;
+  }
+
+  if (include?.audio) {
+    clone.audio = story.audio;
+  } else {
+    delete clone.audio;
+  }
+
+  return clone;
+}
+
+function resolveStory(story: MockStory | undefined, include?: StoryInclude) {
+  if (!story) return null;
+  return cloneStory(story, include);
+}
+
+function extractSlug(args: { slug?: string; id?: string }) {
+  return args.slug ?? null;
+}
+
+function extractId(args: { slug?: string; id?: string }) {
+  return args.id ?? null;
+}
+
+function getBodyFromCreate(input: Record<string, unknown>, storyId: string) {
+  const body = (input as { body?: { create?: StoryBody } }).body;
+  if (body?.create) {
+    return { ...body.create, storyId };
+  }
+  return null;
+}
+
+function applyBodyUpdate(story: MockStory, update: Record<string, unknown>) {
+  const body = (
+    update as {
+      body?: {
+        upsert?: { update?: StoryBody; create?: StoryBody };
+        create?: StoryBody;
+      };
+    }
+  ).body;
+  if (!body) return story.body;
+
+  if ("upsert" in body && body.upsert) {
+    if (story.body && body.upsert.update) {
+      story.body = { ...story.body, ...body.upsert.update };
+    } else if (!story.body && body.upsert.create) {
+      story.body = { ...body.upsert.create, storyId: story.id };
+    }
+  } else if ("create" in body && body.create) {
+    story.body = { ...body.create, storyId: story.id };
+  }
+  return story.body;
+}
+
+export function createMockPrisma(): PrismaClient {
+  const storiesBySlug = new Map<string, MockStory>();
+  const storiesById = new Map<string, MockStory>();
+  const freeRotations = new Map<string, FreeRotationRecord>();
+
+  const story = {
+    async findUnique(args: FindUniqueArgs) {
+      const slug = args.where.slug;
+      const id = args.where.id;
+      const record = slug
+        ? storiesBySlug.get(slug)
+        : id
+          ? storiesById.get(id)
+          : undefined;
+      return resolveStory(record, args.include);
+    },
+    async upsert(args: UpsertArgs) {
+      const slug = extractSlug(args.where);
+      const idFromWhere = extractId(args.where);
+      let existing: MockStory | undefined;
+      if (slug) {
+        existing = storiesBySlug.get(slug);
+      } else if (idFromWhere) {
+        existing = storiesById.get(idFromWhere);
+      }
+
+      if (existing) {
+        Object.entries(args.update).forEach(([key, value]) => {
+          if (key === "body") return;
+          (existing as Record<string, unknown>)[key] = value;
+        });
+        existing.updatedAt = new Date();
+        applyBodyUpdate(existing, args.update);
+      } else {
+        const id = randomUUID();
+        const createdAt = new Date();
+        const newStory: MockStory = {
+          id,
+          slug: (args.create as { slug: string }).slug,
+          title: (args.create as { title: string }).title,
+          description: (args.create as { description: string }).description,
+          tags: ((args.create as { tags?: string[] }).tags ?? []).slice(),
+          ageMin: (args.create as { ageMin: number }).ageMin,
+          ageMax: (args.create as { ageMax: number }).ageMax,
+          status: (args.create as { status: string }).status,
+          createdAt,
+          updatedAt: createdAt,
+          publishedAt:
+            (args.create as { publishedAt?: Date | null }).publishedAt ?? null,
+          body: null,
+          audio: null,
+        };
+        newStory.body = getBodyFromCreate(args.create, id);
+        storiesBySlug.set(newStory.slug, newStory);
+        storiesById.set(newStory.id, newStory);
+        existing = newStory;
+      }
+
+      if (existing.slug) {
+        storiesBySlug.set(existing.slug, existing);
+      }
+      storiesById.set(existing.id, existing);
+      return resolveStory(existing, args.include);
+    },
+  };
+
+  const freeRotation = {
+    async findUnique(args: { where: { storyId: string } }) {
+      return freeRotations.get(args.where.storyId) ?? null;
+    },
+    async deleteMany(args: DeleteManyArgs) {
+      if (!args.where?.storyId) {
+        const count = freeRotations.size;
+        freeRotations.clear();
+        return { count };
+      }
+      const existed = freeRotations.delete(args.where.storyId) ? 1 : 0;
+      return { count: existed };
+    },
+  };
+
+  const user = {
+    async findUnique() {
+      return null;
+    },
+  };
+
+  const mockClient = {
+    story,
+    freeRotation,
+    user,
+    async $disconnect() {
+      return;
+    },
+  };
+
+  return mockClient as unknown as PrismaClient;
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,22 @@
 import { defineConfig } from "@playwright/test";
+
+const shouldUseMockPrisma = !process.env.DATABASE_URL;
+if (shouldUseMockPrisma && !process.env.USE_MOCK_PRISMA) {
+  process.env.USE_MOCK_PRISMA = "1";
+}
+
+const webServerEnv = (() => {
+  if (!shouldUseMockPrisma) return undefined;
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (typeof value === "string") {
+      env[key] = value;
+    }
+  }
+  env.USE_MOCK_PRISMA = process.env.USE_MOCK_PRISMA ?? "1";
+  return env;
+})();
+
 export default defineConfig({
   tsconfig: "./tsconfig.playwright.json",
   testDir: "tests/e2e",
@@ -7,6 +25,7 @@ export default defineConfig({
     url: "http://localhost:3000",
     timeout: 120 * 1000,
     reuseExistingServer: !process.env.CI,
+    env: webServerEnv,
   },
   use: { baseURL: "http://localhost:3000" },
 });

--- a/tests/e2e/paywall.spec.ts
+++ b/tests/e2e/paywall.spec.ts
@@ -1,7 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import { prisma } from "@/lib/prisma";
 
 const slug = "paywall-e2e-story";
 


### PR DESCRIPTION
## Summary
- add an in-memory Prisma mock that supports the subset of operations used in e2e tests
- switch the paywall e2e to reuse the shared Prisma instance instead of creating a new client
- auto-enable the mock client when DATABASE_URL is missing so Playwright can boot the app in CI

## Testing
- pnpm lint
- pnpm e2e *(fails: Playwright browsers missing in runner)*

------
https://chatgpt.com/codex/tasks/task_e_68d38a8a0fcc832cba69b4e2f247d85c