### PR TITLE
fix: guard external integrations during build

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,10 +3,15 @@ import { prisma } from "@/lib/prisma";
 import { absoluteUrl } from "@/lib/seo";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const stories = await prisma.story.findMany({
-    where: { status: "PUBLISHED" },
-    select: { slug: true, updatedAt: true },
-  });
+  let stories: { slug: string; updatedAt: Date | null }[] = [];
+  try {
+    stories = await prisma.story.findMany({
+      where: { status: "PUBLISHED" },
+      select: { slug: true, updatedAt: true },
+    });
+  } catch {
+    stories = [];
+  }
 
   const staticRoutes = [
     "/",

--- a/auth.ts
+++ b/auth.ts
@@ -5,16 +5,25 @@ import { prisma } from "@/lib/prisma";
 import type { User } from "@prisma/client";
 import type { JWT } from "next-auth/jwt";
 
+const emailServer = process.env.EMAIL_SERVER;
+const emailFrom = process.env.EMAIL_FROM;
+
+const providers: NextAuthConfig["providers"] = [];
+
+if (emailServer && emailFrom) {
+  providers.push(
+    EmailProvider({
+      server: emailServer,
+      from: emailFrom,
+      maxAge: 10 * 60,
+    }),
+  );
+}
+
 export const authConfig: NextAuthConfig = {
   adapter: PrismaAdapter(prisma),
   session: { strategy: "jwt" },
-  providers: [
-    EmailProvider({
-      server: process.env.EMAIL_SERVER!,
-      from: process.env.EMAIL_FROM!,
-      maxAge: 10 * 60,
-    }),
-  ],
+  providers,
   callbacks: {
     async jwt({ token, user }) {
       if (user) token.role = (user as User).role ?? "USER";

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,27 +1,50 @@
 import { MeiliSearch } from "meilisearch";
+import type { Index } from "meilisearch";
 import type { Story } from "@prisma/client";
 
-const client = new MeiliSearch({
-  host: process.env.MEILI_HOST!,
-  apiKey: process.env.MEILI_API_KEY,
-});
+let client: MeiliSearch | null = null;
+
+function getClient() {
+  const host = process.env.MEILI_HOST;
+  if (!host) return null;
+  if (client) return client;
+  try {
+    client = new MeiliSearch({
+      host,
+      apiKey: process.env.MEILI_API_KEY,
+    });
+    return client;
+  } catch {
+    client = null;
+    return null;
+  }
+}
 const indexName = process.env.MEILI_INDEX_STORIES || "stories";
 
-export async function ensureStoryIndex() {
-  await client.createIndex(indexName, { primaryKey: "id" }).catch(() => {});
-  const index = client.index(indexName);
-  await index.updateSettings({
-    searchableAttributes: ["title", "description", "tags"],
-    filterableAttributes: ["ageMin", "ageMax", "status"],
-    sortableAttributes: ["publishedAt"],
-  });
-  return index;
+export async function ensureStoryIndex(): Promise<Index<
+  Record<string, unknown>
+> | null> {
+  const meiliClient = getClient();
+  if (!meiliClient) return null;
+  await meiliClient
+    .createIndex(indexName, { primaryKey: "id" })
+    .catch(() => {});
+  const index = meiliClient.index(indexName);
+  await index
+    .updateSettings({
+      searchableAttributes: ["title", "description", "tags"],
+      filterableAttributes: ["ageMin", "ageMax", "status"],
+      sortableAttributes: ["publishedAt"],
+    })
+    .catch(() => {});
+  return index as Index<Record<string, unknown>>;
 }
 
 export async function upsertStoryIndex(
   s: Story & { body?: { html: string | null } | null },
 ) {
   const index = await ensureStoryIndex();
+  if (!index) return;
   await index.addDocuments([
     {
       id: s.id,
@@ -40,6 +63,7 @@ export async function upsertStoryIndex(
 export async function searchStories(q: string) {
   try {
     const index = await ensureStoryIndex();
+    if (!index) return { hits: [] };
     return await index.search(q, { limit: 10 });
   } catch {
     return { hits: [] };


### PR DESCRIPTION
## Summary
- avoid instantiating MeiliSearch client when configuration is missing so build-time search calls fall back gracefully
- only register the nodemailer NextAuth provider when email configuration is provided
- tolerate database connection failures when generating the sitemap to allow static builds without a database

## Testing
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d4d9a9036c832c8c0eabc7479169e6